### PR TITLE
Enhance MCP and NLQ functionalities

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -7,7 +7,8 @@ The backend is a Laravel 10 application responsible for serving predictive risk 
 - **Hex aggregation API** – `/api/hexes` and `/api/hexes/geojson` expose validated aggregation responses with PSR-12 compliant controllers and DTO-backed services.
 - **H3 integration** – services gracefully resolve either the PHP H3 extension or compatible FFI bindings at runtime.
 - **Police archive ingestion** – resilient downloader normalises, deduplicates, and bulk inserts police records with H3 enrichment.
-- **MCP support** – `php artisan mcp:serve` exposes the API’s capabilities to Model Context Protocol compatible clients.
+- **MCP support** – `php artisan mcp:serve` exposes the API’s capabilities to Model Context Protocol compatible clients and now includes discovery helpers such as `get_categories`, `list_ingested_months`, and `get_top_cells`.
+
 
 ## Project conventions
 
@@ -38,6 +39,27 @@ php artisan test
 | `php artisan crimes:ingest 2024-03` | Download and import a police archive for March 2024. |
 | `php artisan schedule:run` | Trigger scheduled ingestion or housekeeping tasks. |
 | `php artisan mcp:serve` | Start the Model Context Protocol bridge for the Predictive Patterns API. |
+
+## HTTP endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/hexes` | Aggregated counts for H3 cells intersecting a bounding box. Supports `bbox`, `resolution`, `from`, `to`, and `crime_type` query parameters. |
+| `GET` | `/api/hexes/geojson` | GeoJSON feature collection for aggregated H3 cells. |
+| `GET` | `/api/export` | Download aggregated data as CSV (default) or GeoJSON via `format=geojson`. Accepts the same filters as `/api/hexes`. |
+| `POST` | `/api/nlq` | Ask a natural-language question and receive a structured answer describing the translated query. |
+
+## MCP toolset
+
+| Tool | Purpose |
+|------|---------|
+| `aggregate_hexes` | Aggregate crime counts for a bounding box. |
+| `export_geojson` | Produce a GeoJSON feature collection for crime aggregates. |
+| `get_categories` | List distinct crime categories available in the datastore. |
+| `get_top_cells` | Return the highest ranking H3 cells for the supplied filters. |
+| `ingest_crime_data` | Queue a background job to ingest a month of police crime data. |
+| `list_ingested_months` | Summarise the months currently present in the relational store. |
+
 
 ## Environment variables
 

--- a/backend/app/Http/Controllers/Api/v1/ExportController.php
+++ b/backend/app/Http/Controllers/Api/v1/ExportController.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1;
+
+use App\Http\Controllers\Controller;
+use App\Services\H3AggregationService;
+use App\Services\H3GeometryService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Response;
+use JsonException;
+
+class ExportController extends Controller
+{
+    /**
+     * Export aggregated crime data within a bounding box to CSV or GeoJSON format.
+     *
+     * @param Request $request
+     * @param H3AggregationService $aggregationService
+     * @param H3GeometryService $geometryService
+     *
+     * @return \Illuminate\Http\Response|JsonResponse
+     * @throws JsonException
+     */
+    public function __invoke(
+        Request              $request,
+        H3AggregationService $aggregationService,
+        H3GeometryService    $geometryService
+    ): \Illuminate\Http\Response|JsonResponse
+    {
+        $bbox = $request->string('bbox') ?? '-180,-90,180,90';
+        $resolution = (int)($request->integer('resolution') ?? 7);
+        $from = $request->input('from');
+        $to = $request->input('to');
+        $crimeType = $request->input('crime_type');
+        $format = strtolower((string)($request->string('format') ?? $request->string('type') ?? 'csv'));
+
+        $aggregated = $aggregationService->aggregateByBbox($bbox, $resolution, $from, $to, $crimeType);
+
+        if ($format === 'geojson' || str_contains($request->header('accept', ''), 'geo+json')) {
+            return $this->exportGeoJson($aggregated, $geometryService, $resolution);
+        }
+
+        return $this->exportCsv($aggregated, $resolution);
+    }
+
+    /**
+     * @param array<string, array{count: int, categories: array<string, int>}> $data
+     * @param int $resolution
+     *
+     * @return \Illuminate\Http\Response
+     * @throws JsonException
+     */
+    private function exportCsv(array $data, int $resolution): \Illuminate\Http\Response
+    {
+        $handle = fopen('php://temp', 'r+');
+        fputcsv($handle, ['h3', 'resolution', 'count', 'categories']);
+
+        foreach ($data as $h3 => $payload) {
+            fputcsv($handle, [
+                $h3,
+                $resolution,
+                $payload['count'],
+                json_encode($payload['categories'], JSON_THROW_ON_ERROR),
+            ]);
+        }
+
+        rewind($handle);
+        $csv = stream_get_contents($handle) ?: '';
+        fclose($handle);
+
+        return Response::make($csv, 200, [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => 'attachment; filename="crime-export.csv"',
+        ]);
+    }
+
+    /**
+     * Export data to GeoJSON format.
+     *
+     * @param array<string, array{count: int, categories: array<string, int>}> $data
+     * @param H3GeometryService $geometryService
+     * @param int $resolution
+     *
+     * @return JsonResponse
+     */
+    private function exportGeoJson(array $data, H3GeometryService $geometryService, int $resolution): JsonResponse
+    {
+        $features = [];
+        foreach ($data as $h3 => $payload) {
+            $features[] = [
+                'type' => 'Feature',
+                'properties' => [
+                    'h3' => $h3,
+                    'resolution' => $resolution,
+                    'count' => $payload['count'],
+                    'categories' => $payload['categories'],
+                ],
+                'geometry' => [
+                    'type' => 'Polygon',
+                    'coordinates' => [
+                        $geometryService->polygonCoordinates($h3),
+                    ],
+                ],
+            ];
+        }
+
+        return Response::json([
+            'type' => 'FeatureCollection',
+            'features' => $features,
+        ], 200, [
+            'Content-Type' => 'application/geo+json',
+            'Content-Disposition' => 'attachment; filename="crime-export.geojson"',
+        ], JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/backend/app/Http/Controllers/Api/v1/HexController.php
+++ b/backend/app/Http/Controllers/Api/v1/HexController.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api\v1;
 
-use App\Services\H3GeometryService;
+use App\Http\Controllers\Controller;
 use App\Services\H3AggregationService;
+use App\Services\H3GeometryService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -22,8 +23,9 @@ class HexController extends Controller
         $res = (int)($r->integer('resolution') ?? 7);
         $from = $r->input('from');
         $to = $r->input('to');
+        $crimeType = $r->input('crime_type');
 
-        $agg = $svc->aggregateByBbox($bbox, $res, $from, $to);
+        $agg = $svc->aggregateByBbox($bbox, $res, $from, $to, $crimeType);
 
         $cells = [];
         foreach ($agg as $h3 => $data) {
@@ -40,15 +42,16 @@ class HexController extends Controller
      *
      * @return JsonResponse
      */
-    public function geojson(Request $r, H3AggregationService $svc, H3GeometryService $geo): JsonResponse
+    public function geoJson(Request $r, H3AggregationService $svc, H3GeometryService $geo): JsonResponse
     {
         $bbox = $r->string('bbox') ?? abort(422, 'bbox required');
 
         $res = (int)($r->integer('resolution') ?? 7);
         $from = $r->input('from');
         $to = $r->input('to');
+        $crimeType = $r->input('crime_type');
 
-        $agg = $svc->aggregateByBbox($bbox, $res, $from, $to);
+        $agg = $svc->aggregateByBbox($bbox, $res, $from, $to, $crimeType);
 
         $features = [];
         foreach ($agg as $h3 => $data) {

--- a/backend/app/Http/Controllers/Api/v1/NlqController.php
+++ b/backend/app/Http/Controllers/Api/v1/NlqController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1;
+
+use App\Http\Controllers\Controller;
+use App\Services\NaturalLanguageQueryService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class NlqController extends Controller
+{
+    public function __construct(private readonly NaturalLanguageQueryService $nlqService)
+    {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'question' => ['required', 'string', 'min:3'],
+        ]);
+
+        $question = (string) $validated['question'];
+        $answer = $this->nlqService->answer($question);
+
+        return response()->json($answer);
+    }
+}

--- a/backend/app/MCP/CrimeMcpServer.php
+++ b/backend/app/MCP/CrimeMcpServer.php
@@ -2,69 +2,129 @@
 namespace App\MCP;
 
 use App\Jobs\IngestPoliceCrimes;
+use App\Models\Crime;
 use App\Services\H3AggregationService;
 use InvalidArgumentException;
 use Throwable;
 
 class CrimeMcpServer {
-  public function run(): void {
-    while (($line = fgets(STDIN)) !== false) {
-      $resp = $this->dispatch($line);
-      fwrite(STDOUT, json_encode($resp, JSON_UNESCAPED_SLASHES).PHP_EOL);
-      fflush(STDOUT);
-    }
-  }
-
-  private function dispatch(string $raw): array {
-    try {
-      $msg = json_decode(trim($raw), true, 512, JSON_THROW_ON_ERROR);
-      $id  = $msg['id'] ?? null;
-      $tool= $msg['tool'] ?? null;
-      $args= $msg['arguments'] ?? [];
-
-      return [
-        'id' => $id,
-        'result' => match ($tool) {
-          'aggregate_hexes' => $this->aggregate($args),
-          'ingest_crime_data' => $this->ingest($args),
-          'export_geojson' => $this->export($args),
-          default => ['error' => 'unknown_tool']
+    public function run(): void {
+        while (($line = fgets(STDIN)) !== false) {
+            $resp = $this->dispatch($line);
+            fwrite(STDOUT, json_encode($resp, JSON_UNESCAPED_SLASHES).PHP_EOL);
+            fflush(STDOUT);
         }
-      ];
-    } catch (Throwable $e) {
-      return ['error' => 'bad_request', 'message' => $e->getMessage()];
     }
-  }
 
-  private function aggregate(array $a): array {
-    $bbox = $a['bbox'] ?? throw new InvalidArgumentException('bbox required');
-    $res  = (int)($a['resolution'] ?? 7);
-    $from = $a['from'] ?? null;
-    $to   = $a['to'] ?? null;
-    $svc  = app(H3AggregationService::class);
-    $agg  = $svc->aggregateByBbox($bbox, $res, $from, $to);
+    private function dispatch(string $raw): array {
+        try {
+            $msg = json_decode(trim($raw), true, 512, JSON_THROW_ON_ERROR);
+            $id  = $msg['id'] ?? null;
+            $tool= $msg['tool'] ?? null;
+            $args= $msg['arguments'] ?? [];
 
-    $cells = [];
-    foreach ($agg as $h3 => $data) {
-      $cells[] = ['h3'=>$h3,'count'=>$data['count'],'categories'=>$data['categories']];
+            return [
+                'id' => $id,
+                'result' => match ($tool) {
+                    'aggregate_hexes' => $this->aggregate($args),
+                    'ingest_crime_data' => $this->ingest($args),
+                    'export_geojson' => $this->export($args),
+                    'get_categories' => $this->categories(),
+                    'list_ingested_months' => $this->ingestedMonths(),
+                    'get_top_cells' => $this->topCells($args),
+                    default => ['error' => 'unknown_tool']
+                }
+            ];
+        } catch (Throwable $e) {
+            return ['error' => 'bad_request', 'message' => $e->getMessage()];
+        }
     }
-    return ['resolution'=>$res,'cells'=>$cells];
-  }
 
-  private function ingest(array $a): array {
-    $ym = $a['ym'] ?? throw new InvalidArgumentException('ym required YYYY-MM');
-    dispatch(new IngestPoliceCrimes($ym));
-    return ['status'=>'queued','ym'=>$ym];
-  }
+    private function aggregate(array $a): array {
+        $bbox = $a['bbox'] ?? throw new InvalidArgumentException('bbox required');
+        $res  = (int)($a['resolution'] ?? 7);
+        $from = $a['from'] ?? null;
+        $to   = $a['to'] ?? null;
+        $svc  = app(H3AggregationService::class);
+        $agg  = $svc->aggregateByBbox($bbox, $res, $from, $to, $a['crime_type'] ?? null);
 
-  private function export(array $a): array {
-    $res = (int)($a['resolution'] ?? 7);
-    $bbox= $a['bbox'] ?? throw new InvalidArgumentException('bbox required');
-    $agg = app(H3AggregationService::class)->aggregateByBbox($bbox, $res, $a['from'] ?? null, $a['to'] ?? null);
-    $features = [];
-    foreach ($agg as $h3 => $data) {
-      $features[] = ['type'=>'Feature','properties'=>['h3'=>$h3,'count'=>$data['count']],'geometry'=>null];
+        $cells = [];
+        foreach ($agg as $h3 => $data) {
+            $cells[] = ['h3'=>$h3,'count'=>$data['count'],'categories'=>$data['categories']];
+        }
+        return ['resolution'=>$res,'cells'=>$cells];
     }
-    return ['type'=>'FeatureCollection','features'=>$features];
-  }
+
+    private function ingest(array $a): array {
+        $ym = $a['ym'] ?? throw new InvalidArgumentException('ym required YYYY-MM');
+        dispatch(new IngestPoliceCrimes($ym));
+        return ['status'=>'queued','ym'=>$ym];
+    }
+
+    private function export(array $a): array {
+        $res = (int)($a['resolution'] ?? 7);
+        $bbox= $a['bbox'] ?? throw new InvalidArgumentException('bbox required');
+        $agg = app(H3AggregationService::class)->aggregateByBbox($bbox, $res, $a['from'] ?? null, $a['to'] ?? null, $a['crime_type'] ?? null);
+        $features = [];
+        foreach ($agg as $h3 => $data) {
+            $features[] = ['type'=>'Feature','properties'=>['h3'=>$h3,'count'=>$data['count']],'geometry'=>null];
+        }
+        return ['type'=>'FeatureCollection','features'=>$features];
+    }
+
+    private function categories(): array {
+        $categories = Crime::query()
+            ->select('category')
+            ->distinct()
+            ->whereNotNull('category')
+            ->orderBy('category')
+            ->pluck('category')
+            ->map(fn ($value) => (string) $value)
+            ->values()
+            ->all();
+
+        return ['categories' => $categories];
+    }
+
+    private function ingestedMonths(): array {
+        $rows = Crime::query()
+            ->selectRaw("DATE_FORMAT(occurred_at, '%Y-%m') as ym, COUNT(*) as c")
+            ->groupBy('ym')
+            ->orderBy('ym', 'desc')
+            ->get()
+            ->map(fn ($row) => ['month' => (string) $row->ym, 'count' => (int) ($row->c ?? 0)])
+            ->all();
+
+        return ['months' => $rows];
+    }
+
+    private function topCells(array $args): array {
+        $bbox = $args['bbox'] ?? '-180,-90,180,90';
+        $resolution = (int)($args['resolution'] ?? 7);
+        $limit = max(1, (int)($args['limit'] ?? 5));
+        $from = $args['from'] ?? null;
+        $to = $args['to'] ?? null;
+        $crimeType = $args['crime_type'] ?? null;
+
+        $agg = app(H3AggregationService::class)->aggregateByBbox($bbox, $resolution, $from, $to, $crimeType);
+        $cells = [];
+        foreach ($agg as $h3 => $payload) {
+            $cells[] = ['h3' => $h3, 'count' => $payload['count'], 'categories' => $payload['categories']];
+        }
+
+        usort($cells, static fn($a, $b) => $b['count'] <=> $a['count']);
+        $cells = array_slice($cells, 0, $limit);
+
+        return [
+            'resolution' => $resolution,
+            'limit' => $limit,
+            'filters' => array_filter([
+                'bbox' => $bbox,
+                'from' => $from,
+                'to' => $to,
+                'crime_type' => $crimeType,
+            ]),
+            'cells' => $cells,
+        ];
+    }
 }

--- a/backend/app/Services/NaturalLanguageQueryService.php
+++ b/backend/app/Services/NaturalLanguageQueryService.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Crime;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class NaturalLanguageQueryService
+{
+    private const DEFAULT_BBOX = '-180,-90,180,90';
+    private const DEFAULT_RESOLUTION = 7;
+    private const DEFAULT_LIMIT = 5;
+
+    public function __construct(private readonly H3AggregationService $aggregationService)
+    {
+    }
+
+    /**
+     * Translate a natural language question into a structured answer.
+     *
+     * @return array{answer: string, query: array<string, mixed>, data: array<string, mixed>}
+     */
+    public function answer(string $question): array
+    {
+        $normalized = Str::lower(trim($question));
+        $timeRange = $this->detectTimeRange($normalized);
+        $crimeType = $this->detectCrimeType($normalized);
+        $limit = $this->detectLimit($normalized);
+        $resolution = $this->detectResolution($normalized);
+
+        if ($this->isHotspotQuestion($normalized)) {
+            return $this->buildHotspotResponse($question, $timeRange, $crimeType, $limit, $resolution);
+        }
+
+        return $this->buildCountResponse($question, $timeRange, $crimeType);
+    }
+
+    /**
+     * @param array{from: CarbonInterface|null, to: CarbonInterface|null, label: string} $timeRange
+     */
+    private function buildHotspotResponse(
+        string $question,
+        array $timeRange,
+        ?string $crimeType,
+        int $limit,
+        int $resolution
+    ): array {
+        $aggregated = $this->aggregationService->aggregateByBbox(
+            self::DEFAULT_BBOX,
+            $resolution,
+            $timeRange['from'],
+            $timeRange['to'],
+            $crimeType
+        );
+
+        $cells = [];
+        foreach ($aggregated as $h3 => $payload) {
+            $cells[] = [
+                'h3' => $h3,
+                'count' => $payload['count'],
+                'categories' => $payload['categories'],
+            ];
+        }
+
+        usort($cells, static fn ($a, $b) => $b['count'] <=> $a['count']);
+        $cells = array_slice($cells, 0, $limit);
+
+        $descriptionParts = [];
+        foreach ($cells as $cell) {
+            $descriptionParts[] = sprintf('%s (%d incidents)', $cell['h3'], $cell['count']);
+        }
+
+        $context = $this->buildContextPhrase($crimeType, $timeRange['label']);
+        $answer = $cells
+            ? sprintf('Top %d H3 cells %s: %s.', count($cells), $context, implode(', ', $descriptionParts))
+            : sprintf('No hotspots found %s.', $context);
+
+        return [
+            'answer' => $answer,
+            'query' => [
+                'type' => 'aggregate_hexes',
+                'sql' => 'SELECT h3_res'.$resolution.' AS h3, COUNT(*) AS total FROM crimes WHERE ... GROUP BY h3 ORDER BY total DESC LIMIT '.$limit,
+                'parameters' => array_filter([
+                    'bbox' => self::DEFAULT_BBOX,
+                    'resolution' => $resolution,
+                    'from' => $timeRange['from']?->toIso8601String(),
+                    'to' => $timeRange['to']?->toIso8601String(),
+                    'crime_type' => $crimeType,
+                    'limit' => $limit,
+                ]),
+            ],
+            'data' => [
+                'cells' => $cells,
+                'resolution' => $resolution,
+                'filters' => [
+                    'bbox' => self::DEFAULT_BBOX,
+                    'from' => $timeRange['from']?->toIso8601String(),
+                    'to' => $timeRange['to']?->toIso8601String(),
+                    'crime_type' => $crimeType,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array{from: CarbonInterface|null, to: CarbonInterface|null, label: string} $timeRange
+     */
+    private function buildCountResponse(string $question, array $timeRange, ?string $crimeType): array
+    {
+        $query = Crime::query();
+
+        if ($timeRange['from']) {
+            $query->where('occurred_at', '>=', $timeRange['from']);
+        }
+
+        if ($timeRange['to']) {
+            $query->where('occurred_at', '<=', $timeRange['to']);
+        }
+
+        if ($crimeType) {
+            $query->where('category', $crimeType);
+        }
+
+        $count = (int) $query->count();
+
+        $context = $this->buildContextPhrase($crimeType, $timeRange['label']);
+
+        $answer = $count > 0
+            ? sprintf('There were %d recorded incidents %s.', $count, $context)
+            : sprintf('No incidents were recorded %s.', $context);
+
+        return [
+            'answer' => $answer,
+            'query' => [
+                'type' => 'count',
+                'sql' => 'SELECT COUNT(*) FROM crimes WHERE ...',
+                'parameters' => array_filter([
+                    'from' => $timeRange['from']?->toIso8601String(),
+                    'to' => $timeRange['to']?->toIso8601String(),
+                    'crime_type' => $crimeType,
+                ]),
+            ],
+            'data' => [
+                'total' => $count,
+                'filters' => [
+                    'from' => $timeRange['from']?->toIso8601String(),
+                    'to' => $timeRange['to']?->toIso8601String(),
+                    'crime_type' => $crimeType,
+                ],
+            ],
+        ];
+    }
+
+    private function detectTimeRange(string $question): array
+    {
+        $now = CarbonImmutable::now();
+
+        if (str_contains($question, 'today')) {
+            return [
+                'from' => $now->startOfDay(),
+                'to' => $now->endOfDay(),
+                'label' => 'today',
+            ];
+        }
+
+        if (str_contains($question, 'yesterday')) {
+            $yesterday = $now->subDay();
+            return [
+                'from' => $yesterday->startOfDay(),
+                'to' => $yesterday->endOfDay(),
+                'label' => 'yesterday',
+            ];
+        }
+
+        if (str_contains($question, 'this week')) {
+            return [
+                'from' => $now->startOfWeek(),
+                'to' => $now->endOfWeek(),
+                'label' => 'this week',
+            ];
+        }
+
+        if (str_contains($question, 'last week')) {
+            $start = $now->startOfWeek()->subWeek();
+            return [
+                'from' => $start,
+                'to' => $start->endOfWeek(),
+                'label' => 'last week',
+            ];
+        }
+
+        if (str_contains($question, 'this month')) {
+            return [
+                'from' => $now->startOfMonth(),
+                'to' => $now->endOfMonth(),
+                'label' => 'this month',
+            ];
+        }
+
+        if (str_contains($question, 'last month')) {
+            $start = $now->startOfMonth()->subMonth();
+            return [
+                'from' => $start,
+                'to' => $start->endOfMonth(),
+                'label' => 'last month',
+            ];
+        }
+
+        if (preg_match('/last\s+(\d+)\s+day/', $question, $matches)) {
+            $days = (int) $matches[1];
+            return [
+                'from' => $now->subDays(max($days, 1)),
+                'to' => $now,
+                'label' => sprintf('in the last %d days', $days),
+            ];
+        }
+
+        if (preg_match('/last\s+(\d+)\s+week/', $question, $matches)) {
+            $weeks = (int) $matches[1];
+            return [
+                'from' => $now->subWeeks(max($weeks, 1)),
+                'to' => $now,
+                'label' => sprintf('in the last %d weeks', $weeks),
+            ];
+        }
+
+        if (preg_match('/last\s+(\d+)\s+month/', $question, $matches)) {
+            $months = (int) $matches[1];
+            return [
+                'from' => $now->subMonths(max($months, 1)),
+                'to' => $now,
+                'label' => sprintf('in the last %d months', $months),
+            ];
+        }
+
+        return [
+            'from' => null,
+            'to' => null,
+            'label' => 'across all available records',
+        ];
+    }
+
+    private function detectCrimeType(string $question): ?string
+    {
+        $categories = Cache::remember(
+            'nlq:categories',
+            now()->addHour(),
+            static fn () => Crime::query()
+                ->select('category')
+                ->distinct()
+                ->pluck('category')
+                ->filter()
+                ->map(fn ($value) => (string) $value)
+                ->values()
+                ->all()
+        );
+
+        foreach ($categories as $category) {
+            $needle = Str::lower($category);
+            if ($needle !== '' && str_contains($question, $needle)) {
+                return $category;
+            }
+        }
+
+        return null;
+    }
+
+    private function detectLimit(string $question): int
+    {
+        if (preg_match('/top\s+(\d+)/', $question, $matches)) {
+            return max(1, (int) $matches[1]);
+        }
+
+        if (preg_match('/(\d+)\s+(hotspots|cells|areas)/', $question, $matches)) {
+            return max(1, (int) $matches[1]);
+        }
+
+        return self::DEFAULT_LIMIT;
+    }
+
+    private function detectResolution(string $question): int
+    {
+        if (preg_match('/res(olution)?\s*(\d+)/', $question, $matches)) {
+            $resolution = (int) $matches[2];
+            if (in_array($resolution, [6, 7, 8], true)) {
+                return $resolution;
+            }
+        }
+
+        return self::DEFAULT_RESOLUTION;
+    }
+
+    private function isHotspotQuestion(string $question): bool
+    {
+        return str_contains($question, 'top')
+            || str_contains($question, 'highest')
+            || str_contains($question, 'hotspot')
+            || str_contains($question, 'risk');
+    }
+
+    private function buildContextPhrase(?string $crimeType, string $label): string
+    {
+        $parts = [];
+
+        if ($crimeType) {
+            $parts[] = strtolower($crimeType).' crimes';
+        } else {
+            $parts[] = 'across all crime categories';
+        }
+
+        if ($label) {
+            $parts[] = $label;
+        }
+
+        return implode(' ', $parts);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,7 +1,11 @@
 <?php
 
+use App\Http\Controllers\Api\v1\ExportController;
+use App\Http\Controllers\Api\v1\HexController;
+use App\Http\Controllers\Api\v1\NlqController;
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\HexController;
 
 Route::get('/hexes', [HexController::class, 'index']);
-Route::get('/hexes/geojson', [HexController::class, 'geojson']);
+Route::get('/hexes/geojson', [HexController::class, 'geoJson']);
+Route::get('/export', ExportController::class);
+Route::post('/nlq', NlqController::class);


### PR DESCRIPTION
Expanded H3AggregationService to parse bbox strings, accept category filters, and return keyed aggregates used across controllers and tools.

Extended the hex endpoints, router, and MCP server to support crime-type filtering plus new MCP tools for categories, ingested months, and top cells.

Added filtered export (CSV/GeoJSON) and natural-language query endpoints with dedicated controllers and an NLQ service translating questions into structured responses.