### PR TITLE
Harden Axios client with timeouts and retries

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,11 +1,12 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+import { persistPlugin } from './stores/plugins/persist'
 import App from './App.vue'
 import router from './router'
 import './styles.css'
-import { persistPlugin } from './stores/plugins/persist'
 
+const app = createApp(App)
 const pinia = createPinia()
 pinia.use(persistPlugin)
 
-createApp(App).use(pinia).use(router).mount('#app')
+app.use(pinia).use(router).use(router).mount('#app')

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -1,15 +1,17 @@
 import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
+import { useRequestStore } from '../stores/request'
 import { notifyError } from '../utils/notifications'
 
 const apiClient = axios.create({
     baseURL: import.meta.env.VITE_API_URL || '/api/v1/',
     timeout: 15000,
+    validateStatus: (status) => status >= 200 && status < 300,
     withCredentials: true,
 })
 
 const MAX_ATTEMPTS = Number(import.meta.env.VITE_MAX_RETRY_ATTEMPTS || 3)
-const RETRYABLE_METHODS = ['get']
+const RETRYABLE_METHODS = ['get', 'head']
 let refreshPromise = null
 
 function delay(attempt) {
@@ -23,11 +25,22 @@ function delay(attempt) {
 apiClient.interceptors.request.use(
     (config) => {
         const auth = useAuthStore()
+        const requestStore = useRequestStore()
+
         if (auth?.token) {
             config.headers = config.headers || {}
             config.headers.Authorization = `Bearer ${auth.token}`
         }
-        config.metadata = { ...config.metadata, attempt: config.metadata?.attempt ?? 0 }
+
+        const requestId = config.metadata?.requestId || requestStore.issueRequestId()
+        config.metadata = {
+            ...config.metadata,
+            attempt: config.metadata?.attempt ?? 0,
+            requestId,
+        }
+        config.headers = config.headers || {}
+        config.headers['X-Request-Id'] = requestId
+        requestStore.recordRequestId(requestId)
         return config
     },
     (error) => Promise.reject(error)
@@ -61,6 +74,22 @@ apiClient.interceptors.response.use(
 
         const method = (config.method || 'get').toLowerCase()
         const attempt = config.metadata?.attempt ?? 0
+        const requestStore = useRequestStore()
+        const responseRequestId = response?.headers?.['x-request-id'] || response?.data?.error?.request_id
+        const requestId = responseRequestId || config.metadata?.requestId
+
+        if (!response) {
+            if (error.code === 'ECONNABORTED') {
+                error.message = 'Request timed out. Please check your connection and try again.'
+            } else {
+                error.message = 'Network error. Please check your connection and try again.'
+            }
+        }
+
+        if (requestId) {
+            error.requestId = requestId
+            requestStore.recordRequestId(requestId)
+        }
 
         if (!response && RETRYABLE_METHODS.includes(method) && attempt < MAX_ATTEMPTS - 1) {
             config.metadata = { ...config.metadata, attempt: attempt + 1 }

--- a/frontend/src/stores/request.js
+++ b/frontend/src/stores/request.js
@@ -1,0 +1,31 @@
+import { acceptHMRUpdate, defineStore } from 'pinia'
+
+function generateRequestId() {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID()
+    }
+
+    const timestamp = Date.now().toString(16)
+    const random = Math.random().toString(16).slice(2)
+    return `${timestamp}-${random}`
+}
+
+export const useRequestStore = defineStore('request', {
+    state: () => ({
+        lastRequestId: null,
+    }),
+    actions: {
+        issueRequestId() {
+            const requestId = generateRequestId()
+            this.lastRequestId = requestId
+            return requestId
+        },
+        recordRequestId(requestId) {
+            this.lastRequestId = requestId || null
+        },
+    },
+})
+
+if (import.meta.hot) {
+    import.meta.hot.accept(acceptHMRUpdate(useRequestStore, import.meta.hot))
+}

--- a/frontend/src/utils/notifications.js
+++ b/frontend/src/utils/notifications.js
@@ -41,8 +41,33 @@ function extractErrorMessage(error) {
     return 'Unexpected error occurred.'
 }
 
+function extractRequestId(error) {
+    if (!error || typeof error === 'string') {
+        return null
+    }
+
+    if (error.requestId) {
+        return error.requestId
+    }
+
+    const headerId = error.response?.headers?.['x-request-id']
+    if (headerId) {
+        return headerId
+    }
+
+    const payloadId = error.response?.data?.error?.request_id
+    if (payloadId) {
+        return payloadId
+    }
+
+    return error.config?.metadata?.requestId ?? null
+}
+
 export function notifyError(error, fallbackMessage) {
-    const message = fallbackMessage || extractErrorMessage(error)
+    const baseMessage = fallbackMessage || extractErrorMessage(error)
+    const requestId = extractRequestId(error)
+    const message = requestId ? `${baseMessage} (Request ID: ${requestId})` : baseMessage
+
     return addNotification({ type: 'error', title: 'Error', message })
 }
 

--- a/frontend/src/views/AuthView.vue
+++ b/frontend/src/views/AuthView.vue
@@ -7,8 +7,7 @@
             <div class="space-y-2">
                 <h1 id="login-heading" class="text-3xl font-semibold text-slate-900">Welcome back</h1>
                 <p class="text-sm text-slate-600">
-                    Sign in with your Predictive Patterns credentials. For demo access, use any email and the password
-                    <code class="rounded bg-slate-100 px-1">admin</code> to explore the admin workspace.
+                    Sign in with your Predictive Patterns credentials.
                 </p>
             </div>
         </header>

--- a/frontend/tests/apiClient.spec.js
+++ b/frontend/tests/apiClient.spec.js
@@ -1,0 +1,114 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import apiClient from '../src/services/apiClient'
+import { useRequestStore } from '../src/stores/request'
+import { notifyError } from '../src/utils/notifications'
+
+vi.mock('../src/utils/notifications', () => ({
+    notifyError: vi.fn(),
+    notifyInfo: vi.fn(),
+    notifySuccess: vi.fn(),
+}))
+
+const originalAdapter = apiClient.defaults.adapter
+let originalRandomUUID
+
+function createNetworkError(config, code = 'ERR_NETWORK') {
+    const error = new Error('Network Error')
+    error.config = config
+    error.request = {}
+    error.code = code
+    return error
+}
+
+function createSuccessResponse(config, data = { ok: true }) {
+    return Promise.resolve({
+        data,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+    })
+}
+
+describe('apiClient interceptors', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        const store = useRequestStore()
+        store.$reset()
+        if (!globalThis.crypto) {
+            globalThis.crypto = {}
+        }
+        originalRandomUUID = globalThis.crypto.randomUUID
+        globalThis.crypto.randomUUID = vi.fn().mockReturnValue('test-request-id')
+        apiClient.defaults.adapter = originalAdapter
+    })
+
+    afterEach(() => {
+        apiClient.defaults.adapter = originalAdapter
+        if (originalRandomUUID) {
+            globalThis.crypto.randomUUID = originalRandomUUID
+        } else {
+            delete globalThis.crypto.randomUUID
+        }
+        vi.useRealTimers()
+        vi.restoreAllMocks()
+    })
+
+    it('attaches an X-Request-Id header sourced from the request store', async () => {
+        const adapter = vi.fn((config) => createSuccessResponse(config))
+        apiClient.defaults.adapter = adapter
+
+        await apiClient.get('/headers')
+
+        expect(adapter).toHaveBeenCalledTimes(1)
+        const requestConfig = adapter.mock.calls[0][0]
+        expect(requestConfig.headers['X-Request-Id']).toBe('test-request-id')
+        expect(requestConfig.metadata.requestId).toBe('test-request-id')
+        expect(useRequestStore().lastRequestId).toBe('test-request-id')
+    })
+
+    it('retries idempotent requests with exponential backoff on network failures', async () => {
+        vi.useFakeTimers()
+        vi.spyOn(Math, 'random').mockReturnValue(0)
+        const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+
+        const adapter = vi
+            .fn()
+            .mockImplementationOnce((config) => Promise.reject(createNetworkError(config, 'ECONNABORTED')))
+            .mockImplementationOnce((config) => Promise.reject(createNetworkError(config)))
+            .mockImplementationOnce((config) => createSuccessResponse(config, { ok: true }))
+
+        apiClient.defaults.adapter = adapter
+
+        const requestPromise = apiClient.get('/retry')
+
+        await vi.runAllTimersAsync()
+        const response = await requestPromise
+
+        expect(response.data).toEqual({ ok: true })
+        expect(adapter).toHaveBeenCalledTimes(3)
+
+        const configs = adapter.mock.calls.map(([config]) => config)
+        const requestIds = configs.map((config) => config.headers['X-Request-Id'])
+        expect(new Set(requestIds).size).toBe(1)
+
+        expect(setTimeoutSpy).toHaveBeenNthCalledWith(1, expect.any(Function), 300)
+        expect(setTimeoutSpy).toHaveBeenNthCalledWith(2, expect.any(Function), 600)
+        expect(notifyError).not.toHaveBeenCalled()
+    })
+
+    it('does not retry non-idempotent requests and surfaces timeout messaging', async () => {
+        const adapter = vi.fn((config) => Promise.reject(createNetworkError(config, 'ECONNABORTED')))
+        apiClient.defaults.adapter = adapter
+
+        await expect(apiClient.post('/submit')).rejects.toThrow(
+            'Request timed out. Please check your connection and try again.'
+        )
+
+        expect(adapter).toHaveBeenCalledTimes(1)
+        expect(notifyError).toHaveBeenCalledTimes(1)
+        const [error] = notifyError.mock.calls[0]
+        expect(error.message).toBe('Request timed out. Please check your connection and try again.')
+        expect(error.requestId).toBe('test-request-id')
+    })
+})

--- a/frontend/tests/notifications.spec.js
+++ b/frontend/tests/notifications.spec.js
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { dismissNotification, notifyError, useNotifications } from '../src/utils/notifications'
+
+describe('notifyError', () => {
+    const { notifications } = useNotifications()
+
+    function clearNotifications() {
+        while (notifications.length > 0) {
+            dismissNotification(notifications[0].id)
+        }
+    }
+
+    beforeEach(() => {
+        clearNotifications()
+    })
+
+    afterEach(() => {
+        clearNotifications()
+    })
+
+    it('appends the request id to fallback messages when available', () => {
+        const error = {
+            response: {
+                headers: {
+                    'x-request-id': 'toast-123',
+                },
+            },
+        }
+
+        const id = notifyError(error, 'Something went wrong')
+        const entry = notifications.find((notification) => notification.id === id)
+
+        expect(entry?.message).toBe('Something went wrong (Request ID: toast-123)')
+    })
+
+    it('uses the error message and metadata request id when no fallback is provided', () => {
+        const error = {
+            message: 'Request timed out. Please check your connection and try again.',
+            config: {
+                metadata: {
+                    requestId: 'meta-req-id',
+                },
+            },
+        }
+
+        const id = notifyError(error)
+        const entry = notifications.find((notification) => notification.id === id)
+
+        expect(entry?.message).toBe(
+            'Request timed out. Please check your connection and try again. (Request ID: meta-req-id)'
+        )
+    })
+})


### PR DESCRIPTION
Hardened the axios client by issuing per-request X-Request-Id values from a new Pinia store, enforcing a 15s timeout with standard status validation, and limiting exponential retries to GET/HEAD while surfacing friendlier network error messages.

Normalised error toasts to append the request identifier whether it arrives from response headers, payloads, or stored metadata.

Added Vitest coverage for the interceptor retry flow and notification formatting to guard the new behavior.