### PR TITLE
feat: unify pagination contract across datasets and models

### DIFF
--- a/backend/app/Models/CrimeIngestionRun.php
+++ b/backend/app/Models/CrimeIngestionRun.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\CrimeIngestionStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 
@@ -23,6 +24,8 @@ use Illuminate\Support\Carbon;
  */
 class CrimeIngestionRun extends Model
 {
+    use HasFactory;
+
     protected $table = 'crime_ingestion_runs';
 
     /**

--- a/backend/app/Support/InteractsWithPagination.php
+++ b/backend/app/Support/InteractsWithPagination.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Str;
+
+trait InteractsWithPagination
+{
+    protected function resolvePerPage(Request $request, int $default = 15, int $max = 100): int
+    {
+        $perPage = (int) $request->integer('per_page', $default);
+
+        return max(1, min($perPage, $max));
+    }
+
+    /**
+     * @param Request $request
+     * @param array<string, string|array{column: string, direction?: string}> $allowed
+     * @param string $defaultColumn
+     * @param 'asc'|'desc' $defaultDirection
+     *
+     * @return array{0: string, 1: 'asc'|'desc'}
+     */
+    protected function resolveSort(Request $request, array $allowed, string $defaultColumn, string $defaultDirection = 'asc'): array
+    {
+        $raw = $request->query('sort');
+
+        if (is_array($raw)) {
+            return [$defaultColumn, $defaultDirection];
+        }
+
+        $sort = (string) $raw;
+
+        if ($sort === '') {
+            return [$defaultColumn, $defaultDirection];
+        }
+
+        $direction = Str::startsWith($sort, '-') ? 'desc' : 'asc';
+        $key = ltrim($sort, '-');
+
+        if (!array_key_exists($key, $allowed)) {
+            return [$defaultColumn, $defaultDirection];
+        }
+
+        $column = $allowed[$key];
+
+        if (is_array($column)) {
+            $direction = $column['direction'] ?? $direction;
+            $column = $column['column'];
+        }
+
+        return [$column, $direction === 'desc' ? 'desc' : 'asc'];
+    }
+
+    /**
+     * @template TItem
+     * @param LengthAwarePaginator<TItem> $paginator
+     * @param callable(TItem): array $transformer
+     */
+    protected function formatPaginatedResponse(LengthAwarePaginator $paginator, callable $transformer): array
+    {
+        $data = $paginator
+            ->getCollection()
+            ->map(fn ($item) => $transformer($item))
+            ->all();
+
+        return [
+            'data' => $data,
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+            ],
+            'links' => [
+                'first' => $paginator->url(1),
+                'last' => $paginator->url($paginator->lastPage()),
+                'prev' => $paginator->previousPageUrl(),
+                'next' => $paginator->nextPageUrl(),
+            ],
+        ];
+    }
+}
+

--- a/backend/database/factories/CrimeIngestionRunFactory.php
+++ b/backend/database/factories/CrimeIngestionRunFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\CrimeIngestionStatus;
+use App\Models\CrimeIngestionRun;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+/**
+ * @extends Factory<CrimeIngestionRun>
+ */
+class CrimeIngestionRunFactory extends Factory
+{
+    protected $model = CrimeIngestionRun::class;
+
+    public function definition(): array
+    {
+        $startedAt = Carbon::instance($this->faker->dateTimeBetween('-2 months', 'now'));
+
+        return [
+            'month' => $startedAt->format('Y-m'),
+            'dry_run' => $this->faker->boolean(),
+            'status' => $this->faker->randomElement(array_map(
+                static fn (CrimeIngestionStatus $status): string => $status->value,
+                CrimeIngestionStatus::cases()
+            )),
+            'records_detected' => $this->faker->numberBetween(0, 5_000),
+            'records_expected' => $this->faker->numberBetween(0, 5_000),
+            'records_inserted' => $this->faker->numberBetween(0, 5_000),
+            'records_existing' => $this->faker->numberBetween(0, 5_000),
+            'archive_checksum' => $this->faker->sha256(),
+            'archive_url' => $this->faker->url(),
+            'error_message' => null,
+            'started_at' => $startedAt,
+            'finished_at' => (clone $startedAt)->addMinutes($this->faker->numberBetween(5, 120)),
+        ];
+    }
+}
+

--- a/backend/tests/Feature/DatasetApiTest.php
+++ b/backend/tests/Feature/DatasetApiTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Enums\CrimeIngestionStatus;
 use App\Enums\Role;
+use App\Models\CrimeIngestionRun;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
@@ -39,5 +41,54 @@ class DatasetApiTest extends TestCase
             'name' => 'Test Dataset',
             'status' => 'ready',
         ]);
+    }
+
+    public function test_runs_endpoint_supports_pagination_filters_and_sorting(): void
+    {
+        $tokens = $this->issueTokensForRole(Role::Admin);
+
+        CrimeIngestionRun::factory()->create([
+            'id' => 1,
+            'status' => CrimeIngestionStatus::Completed,
+            'dry_run' => false,
+            'started_at' => now(),
+            'records_expected' => 200,
+        ]);
+
+        CrimeIngestionRun::factory()->create([
+            'id' => 2,
+            'status' => CrimeIngestionStatus::Completed,
+            'dry_run' => true,
+            'started_at' => now()->subDay(),
+            'records_expected' => 150,
+        ]);
+
+        CrimeIngestionRun::factory()->create([
+            'id' => 3,
+            'status' => CrimeIngestionStatus::Failed,
+            'dry_run' => false,
+            'started_at' => now()->subDays(2),
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])->getJson('/api/v1/datasets/runs', [
+            'per_page' => 2,
+            'sort' => '-records_expected',
+            'filter' => [
+                'status' => 'completed',
+                'dry_run' => 'false',
+            ],
+        ]);
+
+        $response->assertOk();
+
+        $payload = $response->json();
+
+        $this->assertCount(1, $payload['data']);
+        $this->assertSame(200, $payload['data'][0]['records_expected']);
+        $this->assertSame(1, $payload['meta']['total']);
+        $this->assertSame(2, $payload['meta']['per_page']);
+        $this->assertSame(1, $payload['meta']['current_page']);
+        $this->assertNull($payload['links']['next']);
+        $this->assertNotNull($payload['links']['first']);
     }
 }

--- a/backend/tests/Feature/DatasetApiTest.php
+++ b/backend/tests/Feature/DatasetApiTest.php
@@ -70,14 +70,17 @@ class DatasetApiTest extends TestCase
             'started_at' => now()->subDays(2),
         ]);
 
-        $response = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])->getJson('/api/v1/datasets/runs', [
+        $query = http_build_query([
             'per_page' => 2,
             'sort' => '-records_expected',
             'filter' => [
                 'status' => 'completed',
                 'dry_run' => 'false',
             ],
-        ]);
+        ], '', '&', PHP_QUERY_RFC3986);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])
+            ->getJson('/api/v1/datasets/runs?'.$query);
 
         $response->assertOk();
 

--- a/backend/tests/Feature/ModelApiTest.php
+++ b/backend/tests/Feature/ModelApiTest.php
@@ -84,7 +84,7 @@ class ModelApiTest extends TestCase
             'tag' => 'baseline',
         ]);
 
-        $response = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])->getJson('/api/v1/models', [
+        $firstPageQuery = http_build_query([
             'page' => 1,
             'per_page' => 1,
             'sort' => '-trained_at',
@@ -92,7 +92,10 @@ class ModelApiTest extends TestCase
                 'status' => 'active',
                 'tag' => 'baseline',
             ],
-        ]);
+        ], '', '&', PHP_QUERY_RFC3986);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])
+            ->getJson('/api/v1/models?'.$firstPageQuery);
 
         $response->assertOk();
 
@@ -104,7 +107,7 @@ class ModelApiTest extends TestCase
         $this->assertSame(1, $payload['meta']['current_page']);
         $this->assertNotEmpty($payload['links']['next']);
 
-        $secondPage = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])->getJson('/api/v1/models', [
+        $secondPageQuery = http_build_query([
             'page' => 2,
             'per_page' => 1,
             'sort' => '-trained_at',
@@ -112,7 +115,10 @@ class ModelApiTest extends TestCase
                 'status' => 'active',
                 'tag' => 'baseline',
             ],
-        ]);
+        ], '', '&', PHP_QUERY_RFC3986);
+
+        $secondPage = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])
+            ->getJson('/api/v1/models?'.$secondPageQuery);
 
         $secondPage->assertOk();
 

--- a/backend/tests/Feature/ModelApiTest.php
+++ b/backend/tests/Feature/ModelApiTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Enums\ModelStatus;
 use App\Enums\Role;
 use App\Jobs\EvaluateModelJob;
 use App\Jobs\TrainModelJob;
@@ -52,5 +53,72 @@ class ModelApiTest extends TestCase
         $response->assertAccepted();
 
         Bus::assertDispatched(EvaluateModelJob::class);
+    }
+
+    public function test_index_returns_paginated_collection_with_filters_and_sorting(): void
+    {
+        $tokens = $this->issueTokensForRole(Role::Admin);
+
+        PredictiveModel::factory()->create([
+            'id' => 'model-latest',
+            'name' => 'Latest Model',
+            'status' => ModelStatus::Active,
+            'tag' => 'baseline',
+            'trained_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        PredictiveModel::factory()->create([
+            'id' => 'model-older',
+            'name' => 'Older Model',
+            'status' => ModelStatus::Active,
+            'tag' => 'baseline',
+            'trained_at' => now()->subDay(),
+            'updated_at' => now()->subDay(),
+        ]);
+
+        PredictiveModel::factory()->create([
+            'id' => 'model-other',
+            'name' => 'Filtered Model',
+            'status' => ModelStatus::Inactive,
+            'tag' => 'baseline',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])->getJson('/api/v1/models', [
+            'page' => 1,
+            'per_page' => 1,
+            'sort' => '-trained_at',
+            'filter' => [
+                'status' => 'active',
+                'tag' => 'baseline',
+            ],
+        ]);
+
+        $response->assertOk();
+
+        $payload = $response->json();
+
+        $this->assertSame('model-latest', $payload['data'][0]['id']);
+        $this->assertSame(2, $payload['meta']['total']);
+        $this->assertSame(1, $payload['meta']['per_page']);
+        $this->assertSame(1, $payload['meta']['current_page']);
+        $this->assertNotEmpty($payload['links']['next']);
+
+        $secondPage = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])->getJson('/api/v1/models', [
+            'page' => 2,
+            'per_page' => 1,
+            'sort' => '-trained_at',
+            'filter' => [
+                'status' => 'active',
+                'tag' => 'baseline',
+            ],
+        ]);
+
+        $secondPage->assertOk();
+
+        $secondPayload = $secondPage->json();
+
+        $this->assertSame('model-older', $secondPayload['data'][0]['id']);
+        $this->assertNull($secondPayload['links']['next']);
     }
 }

--- a/frontend/src/components/common/PaginationControls.vue
+++ b/frontend/src/components/common/PaginationControls.vue
@@ -1,0 +1,90 @@
+<template>
+    <nav
+        aria-label="Pagination"
+        class="flex flex-wrap items-center justify-between gap-4 border-t border-slate-200 px-6 py-4 text-sm text-slate-600"
+    >
+        <div>
+            <slot
+                name="summary"
+                :from="from"
+                :to="to"
+                :total="total"
+                :label="label"
+            >
+                <span v-if="total">Showing {{ from }}-{{ to }} of {{ total.toLocaleString() }} {{ label }}</span>
+                <span v-else>No {{ label }} available</span>
+            </slot>
+        </div>
+        <div class="flex items-center gap-2">
+            <button
+                class="inline-flex items-center rounded-md border border-slate-300 px-3 py-1.5 font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+                type="button"
+                :disabled="isFirstPage || loading"
+                @click="$emit('previous')"
+            >
+                Previous
+            </button>
+            <span class="font-medium text-slate-900">Page {{ currentPage }} of {{ totalPages }}</span>
+            <button
+                class="inline-flex items-center rounded-md border border-slate-300 px-3 py-1.5 font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+                type="button"
+                :disabled="isLastPage || loading"
+                @click="$emit('next')"
+            >
+                Next
+            </button>
+        </div>
+    </nav>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+    meta: {
+        type: Object,
+        required: true,
+    },
+    count: {
+        type: Number,
+        default: 0,
+    },
+    loading: {
+        type: Boolean,
+        default: false,
+    },
+    label: {
+        type: String,
+        default: 'items',
+    },
+})
+
+defineEmits(['previous', 'next'])
+
+const total = computed(() => Number(props.meta?.total ?? 0))
+const perPage = computed(() => Number(props.meta?.per_page ?? 0))
+const currentPage = computed(() => {
+    const value = Number(props.meta?.current_page ?? 1)
+    return Number.isNaN(value) || value < 1 ? 1 : value
+})
+
+const totalPages = computed(() => {
+    if (!perPage.value) return 1
+    const pages = Math.ceil(total.value / perPage.value)
+    return Number.isNaN(pages) || pages < 1 ? 1 : pages
+})
+
+const from = computed(() => {
+    if (!props.count || !perPage.value) return 0
+    return (currentPage.value - 1) * perPage.value + 1
+})
+
+const to = computed(() => {
+    if (!props.count || !perPage.value) return 0
+    return from.value + props.count - 1
+})
+
+const isFirstPage = computed(() => currentPage.value <= 1)
+const isLastPage = computed(() => currentPage.value >= totalPages.value)
+</script>
+

--- a/frontend/src/components/models/ModelsTable.vue
+++ b/frontend/src/components/models/ModelsTable.vue
@@ -1,33 +1,65 @@
 <template>
     <section class="rounded-xl border border-slate-200 bg-white shadow-sm" aria-labelledby="models-heading">
-        <header class="flex items-center justify-between gap-3 border-b border-slate-200 px-6 py-4">
+        <header class="flex flex-wrap items-center justify-between gap-4 border-b border-slate-200 px-6 py-4">
             <div>
                 <h2 id="models-heading" class="text-lg font-semibold text-slate-900">Models</h2>
                 <p class="text-sm text-slate-600">Monitor deployed models and manage retraining cycles.</p>
             </div>
-            <button
-                class="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-                type="button"
-                @click="refresh"
-            >
-                Refresh
-            </button>
+            <div class="flex flex-wrap items-center gap-3">
+                <label class="flex items-center gap-2 text-sm text-slate-600">
+                    <span>Status</span>
+                    <select
+                        v-model="statusFilter"
+                        class="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                    >
+                        <option v-for="option in statusOptions" :key="option.value" :value="option.value">
+                            {{ option.label }}
+                        </option>
+                    </select>
+                </label>
+                <button
+                    class="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                    type="button"
+                    :disabled="modelStore.loading"
+                    @click="refresh"
+                >
+                    Refresh
+                </button>
+            </div>
         </header>
         <div class="overflow-x-auto">
             <table class="min-w-full divide-y divide-slate-200 text-left text-sm">
                 <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
                     <tr>
-                        <th class="px-6 py-3">Model</th>
-                        <th class="px-6 py-3">Status</th>
-                        <th class="px-6 py-3">Precision</th>
-                        <th class="px-6 py-3">Recall</th>
-                        <th class="px-6 py-3">F1</th>
-                        <th class="px-6 py-3">Last trained</th>
-                        <th class="px-6 py-3" v-if="isAdmin">Actions</th>
+                        <th
+                            v-for="column in columns"
+                            :key="column.key"
+                            :class="['px-6 py-3', column.sortable ? 'cursor-pointer select-none' : '']"
+                            scope="col"
+                            @click="column.sortable ? toggleSort(column.sortKey) : undefined"
+                        >
+                            <div class="flex items-center gap-1">
+                                <span>{{ column.label }}</span>
+                                <span v-if="column.sortable && sortKey === column.sortKey" aria-hidden="true">
+                                    {{ sortDirection === 'asc' ? '▲' : '▼' }}
+                                </span>
+                            </div>
+                        </th>
+                        <th class="px-6 py-3" v-if="isAdmin" scope="col">Actions</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <tr v-for="model in modelStore.models" :key="model.id" class="odd:bg-white even:bg-slate-50">
+                    <tr v-if="modelStore.loading">
+                        <td class="px-6 py-6 text-center text-sm text-slate-500" :colspan="isAdmin ? columns.length + 1 : columns.length">
+                            Loading models…
+                        </td>
+                    </tr>
+                    <tr v-else-if="!modelStore.models.length">
+                        <td class="px-6 py-6 text-center text-sm text-slate-500" :colspan="isAdmin ? columns.length + 1 : columns.length">
+                            No models available.
+                        </td>
+                    </tr>
+                    <tr v-for="model in modelStore.models" v-else :key="model.id" class="odd:bg-white even:bg-slate-50">
                         <td class="px-6 py-3 text-slate-900">
                             <div class="flex flex-col">
                                 <span class="font-medium">{{ model.name }}</span>
@@ -35,17 +67,7 @@
                             </div>
                         </td>
                         <td class="px-6 py-3">
-                            <span
-                                :class="[
-                                    'inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-semibold',
-                                    model.status === 'active'
-                                        ? 'bg-emerald-100 text-emerald-700'
-                                        : 'bg-slate-200 text-slate-700',
-                                ]"
-                            >
-                                <span class="h-2 w-2 rounded-full" :class="model.status === 'active' ? 'bg-emerald-500' : 'bg-slate-500'"></span>
-                                {{ model.status === 'active' ? 'Active' : 'Idle' }}
-                            </span>
+                            <span :class="statusClasses(model.status)">{{ statusLabel(model.status) }}</span>
                         </td>
                         <td class="px-6 py-3">{{ formatMetric(model.metrics?.precision) }}</td>
                         <td class="px-6 py-3">{{ formatMetric(model.metrics?.recall) }}</td>
@@ -72,19 +94,23 @@
                             </div>
                         </td>
                     </tr>
-                    <tr v-if="!modelStore.models.length">
-                        <td class="px-6 py-6 text-center text-sm text-slate-500" :colspan="isAdmin ? 7 : 6">
-                            No models available.
-                        </td>
-                    </tr>
                 </tbody>
             </table>
         </div>
+        <PaginationControls
+            :meta="modelStore.meta"
+            :count="modelStore.models.length"
+            :loading="modelStore.loading"
+            label="models"
+            @previous="previousPage"
+            @next="nextPage"
+        />
     </section>
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import PaginationControls from '../common/PaginationControls.vue'
 import { useAuthStore } from '../../stores/auth'
 import { useModelStore } from '../../stores/model'
 
@@ -92,14 +118,88 @@ const authStore = useAuthStore()
 const modelStore = useModelStore()
 const isAdmin = computed(() => authStore.isAdmin)
 
+const perPage = 10
+const sortKey = ref('updated_at')
+const sortDirection = ref('desc')
+const statusFilter = ref('all')
+
+const columns = [
+    { key: 'name', label: 'Model', sortable: true, sortKey: 'name' },
+    { key: 'status', label: 'Status', sortable: true, sortKey: 'status' },
+    { key: 'precision', label: 'Precision', sortable: false },
+    { key: 'recall', label: 'Recall', sortable: false },
+    { key: 'f1', label: 'F1', sortable: false },
+    { key: 'trained_at', label: 'Last trained', sortable: true, sortKey: 'trained_at' },
+]
+
+const statusOptions = [
+    { value: 'all', label: 'All statuses' },
+    { value: 'active', label: 'Active' },
+    { value: 'inactive', label: 'Inactive' },
+    { value: 'training', label: 'Training' },
+    { value: 'failed', label: 'Failed' },
+    { value: 'draft', label: 'Draft' },
+]
+
 onMounted(() => {
     if (!modelStore.models.length) {
-        modelStore.fetchModels()
+        loadModels()
     }
 })
 
+watch(statusFilter, () => {
+    loadModels(1)
+})
+
+function buildSortParam() {
+    return sortDirection.value === 'desc' ? `-${sortKey.value}` : sortKey.value
+}
+
+function currentFilters() {
+    const filters = {}
+    if (statusFilter.value !== 'all') {
+        filters.status = statusFilter.value
+    }
+    return filters
+}
+
+function loadModels(page = 1) {
+    modelStore.fetchModels({
+        page,
+        perPage,
+        sort: buildSortParam(),
+        filters: currentFilters(),
+    })
+}
+
 function refresh() {
-    modelStore.fetchModels()
+    loadModels(modelStore.meta?.current_page ?? 1)
+}
+
+function nextPage() {
+    const current = Number(modelStore.meta?.current_page ?? 1)
+    const total = Math.ceil((modelStore.meta?.total ?? 0) / (modelStore.meta?.per_page ?? perPage)) || 1
+    if (current < total && !modelStore.loading) {
+        loadModels(current + 1)
+    }
+}
+
+function previousPage() {
+    const current = Number(modelStore.meta?.current_page ?? 1)
+    if (current > 1 && !modelStore.loading) {
+        loadModels(current - 1)
+    }
+}
+
+function toggleSort(key) {
+    if (!key) return
+    if (sortKey.value === key) {
+        sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+    } else {
+        sortKey.value = key
+        sortDirection.value = key === 'name' ? 'asc' : 'desc'
+    }
+    loadModels(1)
 }
 
 function formatMetric(value) {
@@ -113,5 +213,40 @@ function formatDate(value) {
         dateStyle: 'medium',
         timeStyle: 'short',
     }).format(new Date(value))
+}
+
+function statusLabel(status) {
+    switch (status) {
+        case 'active':
+            return 'Active'
+        case 'inactive':
+            return 'Inactive'
+        case 'training':
+            return 'Training'
+        case 'failed':
+            return 'Failed'
+        case 'draft':
+            return 'Draft'
+        default:
+            return status || 'Unknown'
+    }
+}
+
+function statusClasses(status) {
+    const base = 'inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-semibold'
+    switch (status) {
+        case 'active':
+            return `${base} bg-emerald-100 text-emerald-700`
+        case 'training':
+            return `${base} bg-amber-100 text-amber-700`
+        case 'failed':
+            return `${base} bg-rose-100 text-rose-700`
+        case 'inactive':
+            return `${base} bg-slate-200 text-slate-700`
+        case 'draft':
+            return `${base} bg-blue-100 text-blue-700`
+        default:
+            return `${base} bg-slate-200 text-slate-700`
+    }
 }
 </script>


### PR DESCRIPTION
## Summary
- add a shared pagination helper and update the dataset and model APIs to honour page, per_page, sort, and filter parameters while emitting a consistent `{ data, meta, links }` payload
- seed contract coverage with factories and feature tests that exercise the new dataset run and model index response shapes
- introduce reusable pagination controls and refactor the admin datasets view, models table, and model store to consume the standardised API response shape with server-driven filtering and sorting
- mark the shared pagination controls component up as a semantic `<nav>` element for accessible pagination navigation