### PR TITLE
corrections and fixes to tests and cors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,4 +22,4 @@ OCTANE_SERVER=roadrunner
 FRONTEND_URL=http://localhost:5173
 
 MCP_TOKEN=dev-token
-VITE_API_URL=http://localhost:8080/api/v1
+VITE_API_URL=http://localhost:8080/api/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -69,4 +69,4 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
 # Base URL for the predictive API when building the SPA assets.
-VITE_API_URL=http://localhost:8000
+VITE_API_URL=http://localhost:8080

--- a/backend/app/Exceptions/ApiExceptionRenderer.php
+++ b/backend/app/Exceptions/ApiExceptionRenderer.php
@@ -21,7 +21,14 @@ class ApiExceptionRenderer
         if ($exception instanceof ValidationException) {
             $requestId = self::resolveRequestId($request);
             $response = response()->json([
-                'errors' => $exception->errors(),
+                'error' => [
+                    'code' => 'validation_error',
+                    'message' => $exception->getMessage() ?: 'The given data was invalid.',
+                    'details' => [
+                        'errors' => $exception->errors(),
+                    ],
+                    'request_id' => $requestId,
+                ],
             ], $exception->status ?? Response::HTTP_UNPROCESSABLE_ENTITY);
 
             return $response->withHeaders(['X-Request-Id' => $requestId]);

--- a/backend/app/Exceptions/ApiExceptionRenderer.php
+++ b/backend/app/Exceptions/ApiExceptionRenderer.php
@@ -29,6 +29,7 @@ class ApiExceptionRenderer
                     ],
                     'request_id' => $requestId,
                 ],
+                'errors' => $exception->errors(),
             ], $exception->status ?? Response::HTTP_UNPROCESSABLE_ENTITY);
 
             return $response->withHeaders(['X-Request-Id' => $requestId]);

--- a/backend/app/Models/Crime.php
+++ b/backend/app/Models/Crime.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
@@ -10,6 +11,7 @@ use Illuminate\Support\Str;
  */
 class Crime extends Model
 {
+    use HasFactory;
 
     public $incrementing = false;
 

--- a/backend/app/Services/H3GeometryService.php
+++ b/backend/app/Services/H3GeometryService.php
@@ -10,7 +10,7 @@ use RuntimeException;
 /**
  * Normalises access to H3 boundary helpers across the different PHP bindings.
  */
-readonly class H3GeometryService
+class H3GeometryService
 {
     /**
      * Callback that resolves the boundary vertices for a given H3 index.

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -24,8 +24,11 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->group('api', [
+        $middleware->use([
             HandleCors::class,
+        ]);
+
+        $middleware->group('api', [
             SubstituteBindings::class,
         ]);
 

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:7p6dPXnJHMhk83oA5jQUWfvRbUm/jACktgNxWQIYKm0="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/backend/tests/Feature/CorsTest.php
+++ b/backend/tests/Feature/CorsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Http\Response;
+use Tests\TestCase;
+
+class CorsTest extends TestCase
+{
+    /** @test */
+    public function it_adds_cors_headers_to_preflight_requests(): void
+    {
+        $response = $this
+            ->withHeader('Origin', 'http://localhost:5173')
+            ->withHeader('Access-Control-Request-Method', 'POST')
+            ->options('/api/v1/auth/login');
+
+        $response->assertStatus(Response::HTTP_NO_CONTENT);
+        $response->assertHeader('Access-Control-Allow-Origin', 'http://localhost:5173');
+        $response->assertHeader('Access-Control-Allow-Credentials', 'true');
+        $response->assertHeader('Access-Control-Allow-Methods');
+        $response->assertHeader('Access-Control-Allow-Headers');
+    }
+}

--- a/backend/tests/Feature/ModelApiTest.php
+++ b/backend/tests/Feature/ModelApiTest.php
@@ -44,7 +44,8 @@ class ModelApiTest extends TestCase
         $model = PredictiveModel::factory()->create();
         $tokens = $this->issueTokensForRole(Role::Admin);
 
-        $response = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])->postJson("/api/v1/models/{$model->id}/evaluate", [
+        $response = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])
+            ->postJson("/api/v1/models/{$model->id}/evaluate", [
             'dataset_id' => $model->dataset_id,
             'metrics' => ['f1' => 0.82],
             'notes' => 'Smoke test',

--- a/backend/tests/Unit/Exceptions/ApiExceptionRendererTest.php
+++ b/backend/tests/Unit/Exceptions/ApiExceptionRendererTest.php
@@ -81,7 +81,7 @@ class ApiExceptionRendererTest extends TestCase
     {
         $request = Request::create('/api/test', 'GET');
 
-        $exception = new QueryException('select 1', [], new RuntimeException('SQLSTATE[HY000]'));
+        $exception = new QueryException('mysql','select 1', [], new RuntimeException('SQLSTATE[HY000]'));
 
         $response = ApiExceptionRenderer::render($exception, $request);
         $payload = $response->getData(true);


### PR DESCRIPTION
Wrapped validation exceptions in the same JSON error envelope as other API errors so callers receive the code, details, and request ID consistently.

Enabled the Crime model factory by including Laravel’s HasFactory trait, allowing feature tests to seed crimes via factories.

Seeded PHPUnit’s environment with a fixed application key so encryption-dependent services function during tests.