### PR TITLE
Add sessions table migration

### DIFF
--- a/backend/database/migrations/2025_09_13_000000_create_sessions_table.php
+++ b/backend/database/migrations/2025_09_13_000000_create_sessions_table.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+  public function up(): void {
+    Schema::create('sessions', function (Blueprint $table) {
+      $table->string('id')->primary();
+      $table->foreignId('user_id')->nullable()->index();
+      $table->string('ip_address', 45)->nullable();
+      $table->text('user_agent')->nullable();
+      $table->longText('payload');
+      $table->integer('last_activity')->index();
+    });
+  }
+
+  public function down(): void {
+    Schema::dropIfExists('sessions');
+  }
+};


### PR DESCRIPTION
## Summary
- add a migration that creates the `sessions` table used by the database session driver
- ensure session storage table exists so requests no longer throw SQL errors

## Testing
- composer install *(fails: GitHub API requests are blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe98362908326aa270eb6c64738f7