### PR TITLE
Add dashboard view and streamline predict workspace

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -132,7 +132,8 @@ const roleLabel = computed(() => authStore.role.toUpperCase())
 const showChrome = computed(() => isAuthenticated.value && route.name !== 'login')
 
 const primaryLinks = [
-    { to: '/dashboard', label: 'Predict' },
+    { to: '/dashboard', label: 'Dashboard' },
+    { to: '/predict', label: 'Predict' },
     { to: '/admin/models', label: 'Models', adminOnly: true },
     { to: '/admin/datasets', label: 'Datasets', adminOnly: true },
 ]

--- a/frontend/src/components/predict/RecentConfigurationCard.vue
+++ b/frontend/src/components/predict/RecentConfigurationCard.vue
@@ -1,0 +1,48 @@
+<template>
+    <section class="rounded-3xl border border-slate-200/80 bg-white p-6 text-sm shadow-sm shadow-slate-200/70">
+        <header class="mb-4">
+            <p class="text-xs font-semibold uppercase tracking-wider text-slate-500">Recent configuration</p>
+            <h2 class="text-base font-semibold text-slate-900">Last submitted parameters</h2>
+            <p class="mt-1 text-xs text-slate-500">Review the most recent filters applied to the prediction workspace.</p>
+        </header>
+        <dl class="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+            <div>
+                <dt class="text-xs uppercase tracking-wide text-slate-500">Location</dt>
+                <dd class="mt-1 text-sm font-medium text-slate-900">{{ lastLocation }}</dd>
+            </div>
+            <div>
+                <dt class="text-xs uppercase tracking-wide text-slate-500">Forecast horizon</dt>
+                <dd class="mt-1 text-sm font-medium text-slate-900">{{ lastHorizon }}</dd>
+            </div>
+            <div>
+                <dt class="text-xs uppercase tracking-wide text-slate-500">Radius</dt>
+                <dd class="mt-1 text-sm font-medium text-slate-900">{{ lastRadius }}</dd>
+            </div>
+            <div>
+                <dt class="text-xs uppercase tracking-wide text-slate-500">Last run</dt>
+                <dd class="mt-1 text-sm font-medium text-slate-900">{{ lastRunTime }}</dd>
+            </div>
+        </dl>
+    </section>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { usePredictionStore } from '../../stores/prediction'
+
+const predictionStore = usePredictionStore()
+
+const lastLocation = computed(() => predictionStore.lastFilters.center?.label ?? 'Not specified')
+const lastHorizon = computed(() => `${predictionStore.lastFilters.horizon} hours`)
+const lastRadius = computed(() => `${predictionStore.lastFilters.radiusKm.toFixed(1)} km`)
+const lastRunTime = computed(() => {
+    const generatedAt = predictionStore.currentPrediction?.generatedAt
+    if (!generatedAt) {
+        return 'No runs yet'
+    }
+    return new Intl.DateTimeFormat('en-GB', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(new Date(generatedAt))
+})
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -12,6 +12,12 @@ const router = createRouter({
         },
         {
             path: '/dashboard',
+            name: 'dashboard',
+            component: () => import('../views/DashboardView.vue'),
+            meta: { requiresAuth: true },
+        },
+        {
+            path: '/predict',
             name: 'predict',
             component: () => import('../views/PredictView.vue'),
             meta: { requiresAuth: true },
@@ -46,12 +52,12 @@ router.beforeEach((to) => {
 
     if (to.meta.requiresAdmin && !auth.isAdmin) {
         notifyError('Admin privileges are required to access that area.')
-        return { name: 'predict' }
+        return { name: 'dashboard' }
     }
 
     if (to.path.startsWith('/admin') && !auth.isAdmin) {
         notifyError('Admin privileges are required to access that area.')
-        return { name: 'predict' }
+        return { name: 'dashboard' }
     }
 
     return true

--- a/frontend/src/views/AuthView.vue
+++ b/frontend/src/views/AuthView.vue
@@ -64,7 +64,7 @@ async function submit() {
     submitting.value = true
     try {
         await authStore.login({ email: email.value, password: password.value })
-        await router.push({ name: 'predict' });
+        await router.push({ name: 'dashboard' });
     } finally {
         submitting.value = false
     }

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,0 +1,18 @@
+<template>
+    <div class="space-y-6">
+        <header class="space-y-2">
+            <p class="text-xs font-semibold uppercase tracking-wider text-slate-500">Operations overview</p>
+            <h1 class="text-2xl font-semibold text-slate-900">Dashboard</h1>
+            <p class="text-sm text-slate-600">Keep tabs on the latest forecasting inputs and interrogate the data assistant.</p>
+        </header>
+        <div class="grid gap-6 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+            <NLQConsole />
+            <RecentConfigurationCard />
+        </div>
+    </div>
+</template>
+
+<script setup>
+import NLQConsole from '../components/NLQConsole.vue'
+import RecentConfigurationCard from '../components/predict/RecentConfigurationCard.vue'
+</script>

--- a/frontend/src/views/PredictView.vue
+++ b/frontend/src/views/PredictView.vue
@@ -1,7 +1,5 @@
 <template>
-    <div
-        class="grid gap-6 xl:grid-cols-[minmax(0,360px)_minmax(0,1fr)] 2xl:grid-cols-[minmax(0,360px)_minmax(0,1fr)_minmax(0,320px)]"
-    >
+    <div class="grid gap-6 xl:grid-cols-[minmax(0,420px)_minmax(0,1fr)] 2xl:grid-cols-[minmax(0,480px)_minmax(0,1fr)]">
         <section class="rounded-3xl border border-slate-200/80 bg-white p-6 shadow-sm shadow-slate-200/70" aria-labelledby="predict-form-heading">
             <header class="mb-6 space-y-2">
                 <p class="text-xs font-semibold uppercase tracking-wider text-slate-500">Forecast workspace</p>
@@ -17,89 +15,31 @@
                 @submit="handleSubmit"
             />
         </section>
-        <div class="space-y-6">
-            <Suspense>
-                <template #default>
-                    <MapView
-                        :center="mapCenter"
-                        :points="predictionStore.heatmapPoints"
-                        :radius-km="predictionStore.lastFilters.radiusKm"
-                    />
-                </template>
-                <template #fallback>
-                    <div class="h-full min-h-[24rem] rounded-3xl border border-slate-200/80 bg-white p-6 shadow-sm shadow-slate-200/70">
-                        <p class="text-sm text-slate-500">Loading map…</p>
-                    </div>
-                </template>
-            </Suspense>
-
-            <div class="space-y-6 2xl:hidden">
-                <PredictionResult
-                    v-if="predictionStore.hasPrediction"
-                    :features="predictionStore.featureBreakdown"
-                    :radius="predictionStore.lastFilters.radiusKm"
-                    :summary="predictionSummary"
-                />
-                <NLQConsole />
-                <section class="rounded-3xl border border-slate-200/80 bg-white p-6 text-sm shadow-sm shadow-slate-200/70">
-                    <header class="mb-4">
-                        <h2 class="text-base font-semibold text-slate-900">Recent configuration</h2>
-                        <p class="text-xs text-slate-500">Your last submitted parameters are saved for quick iteration.</p>
-                    </header>
-                    <dl class="grid gap-3 sm:grid-cols-2">
-                        <div>
-                            <dt class="text-xs uppercase tracking-wide text-slate-500">Location</dt>
-                            <dd class="mt-1 text-sm font-medium text-slate-900">{{ lastLocation }}</dd>
+        <div class="flex min-h-[28rem] flex-col gap-6">
+            <div class="flex flex-1">
+                <Suspense>
+                    <template #default>
+                        <MapView
+                            class="flex-1 min-h-[28rem]"
+                            :center="mapCenter"
+                            :points="predictionStore.heatmapPoints"
+                            :radius-km="predictionStore.lastFilters.radiusKm"
+                        />
+                    </template>
+                    <template #fallback>
+                        <div class="flex flex-1 min-h-[28rem] items-center justify-center rounded-3xl border border-slate-200/80 bg-white p-6 text-sm shadow-sm shadow-slate-200/70">
+                            <p class="text-sm text-slate-500">Loading map…</p>
                         </div>
-                        <div>
-                            <dt class="text-xs uppercase tracking-wide text-slate-500">Forecast horizon</dt>
-                            <dd class="mt-1 text-sm font-medium text-slate-900">{{ lastHorizon }}</dd>
-                        </div>
-                        <div>
-                            <dt class="text-xs uppercase tracking-wide text-slate-500">Radius</dt>
-                            <dd class="mt-1 text-sm font-medium text-slate-900">{{ lastRadius }}</dd>
-                        </div>
-                        <div>
-                            <dt class="text-xs uppercase tracking-wide text-slate-500">Last run</dt>
-                            <dd class="mt-1 text-sm font-medium text-slate-900">{{ lastRunTime }}</dd>
-                        </div>
-                    </dl>
-                </section>
+                    </template>
+                </Suspense>
             </div>
-        </div>
-        <aside class="hidden 2xl:flex 2xl:w-full 2xl:max-w-sm 2xl:flex-col 2xl:gap-6">
             <PredictionResult
                 v-if="predictionStore.hasPrediction"
                 :features="predictionStore.featureBreakdown"
                 :radius="predictionStore.lastFilters.radiusKm"
                 :summary="predictionSummary"
             />
-            <NLQConsole />
-            <section class="rounded-3xl border border-slate-200/80 bg-white p-6 text-sm shadow-sm shadow-slate-200/70">
-                <header class="mb-4">
-                    <h2 class="text-base font-semibold text-slate-900">Recent configuration</h2>
-                    <p class="text-xs text-slate-500">Your last submitted parameters are saved for quick iteration.</p>
-                </header>
-                <dl class="grid gap-3">
-                    <div>
-                        <dt class="text-xs uppercase tracking-wide text-slate-500">Location</dt>
-                        <dd class="mt-1 text-sm font-medium text-slate-900">{{ lastLocation }}</dd>
-                    </div>
-                    <div>
-                        <dt class="text-xs uppercase tracking-wide text-slate-500">Forecast horizon</dt>
-                        <dd class="mt-1 text-sm font-medium text-slate-900">{{ lastHorizon }}</dd>
-                    </div>
-                    <div>
-                        <dt class="text-xs uppercase tracking-wide text-slate-500">Radius</dt>
-                        <dd class="mt-1 text-sm font-medium text-slate-900">{{ lastRadius }}</dd>
-                    </div>
-                    <div>
-                        <dt class="text-xs uppercase tracking-wide text-slate-500">Last run</dt>
-                        <dd class="mt-1 text-sm font-medium text-slate-900">{{ lastRunTime }}</dd>
-                    </div>
-                </dl>
-            </section>
-        </aside>
+        </div>
     </div>
 </template>
 
@@ -108,7 +48,6 @@ import { computed, defineAsyncComponent, ref } from 'vue'
 import { usePredictionStore } from '../stores/prediction'
 import PredictForm from '../components/predict/PredictForm.vue'
 import PredictionResult from '../components/predict/PredictionResult.vue'
-import NLQConsole from '../components/NLQConsole.vue'
 
 const MapView = defineAsyncComponent(() => import('../components/map/MapView.vue'))
 
@@ -122,20 +61,6 @@ const predictionSummary = computed(() => ({
     riskScore: predictionStore.summary?.riskScore ?? 0,
     confidence: predictionStore.summary?.confidence ?? 'Unknown',
 }))
-
-const lastLocation = computed(() => predictionStore.lastFilters.center?.label ?? 'Not specified')
-const lastHorizon = computed(() => `${predictionStore.lastFilters.horizon} hours`)
-const lastRadius = computed(() => `${predictionStore.lastFilters.radiusKm.toFixed(1)} km`)
-const lastRunTime = computed(() => {
-    const generatedAt = predictionStore.currentPrediction?.generatedAt
-    if (!generatedAt) {
-        return 'No runs yet'
-    }
-    return new Intl.DateTimeFormat('en-GB', {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-    }).format(new Date(generatedAt))
-})
 
 const formErrors = ref({})
 


### PR DESCRIPTION
## Summary
- add a dedicated dashboard view that surfaces the natural language console and recent configuration details
- extract a reusable recent configuration card fed by the prediction store
- widen the predict workspace and map layout after moving supporting panels and update navigation/routing accordingly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0438e80cc8326b2d885e14cf7f1ea