### PR TITLE
Add cached tile heatmap API and frontend tile overlay

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -45,6 +45,7 @@ php artisan test
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/api/hexes` | Aggregated counts for H3 cells intersecting a bounding box. Supports `bbox`, `resolution`, `from`, `to`, and `crime_type` query parameters. |
+| `GET` | `/api/v1/heatmap/{z}/{x}/{y}` | Tile-friendly aggregate payload for the requested XYZ tile. Supports optional `ts_start`, `ts_end`, and `horizon` filters. |
 | `GET` | `/api/hexes/geojson` | GeoJSON feature collection for aggregated H3 cells. |
 | `GET` | `/api/export` | Download aggregated data as CSV (default) or GeoJSON via `format=geojson`. Accepts the same filters as `/api/hexes`. |
 | `POST` | `/api/nlq` | Ask a natural-language question and receive a structured answer describing the translated query. |

--- a/backend/app/Http/Controllers/Api/v1/HeatmapTileController.php
+++ b/backend/app/Http/Controllers/Api/v1/HeatmapTileController.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\HeatmapTileRequest;
+use App\Services\H3AggregationService;
+use App\Services\H3GeometryService;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Cache;
+
+class HeatmapTileController extends Controller
+{
+    private const CACHE_PREFIX = 'heatmap_tiles:';
+    private const CACHE_TTL_MINUTES = 5;
+
+    public function __construct()
+    {
+        $this->middleware(['auth.api', 'throttle:api']);
+    }
+
+    public function __invoke(
+        HeatmapTileRequest $request,
+        H3AggregationService $aggregationService,
+        H3GeometryService $geometryService,
+    ): JsonResponse {
+        $zoom = $request->zoom();
+        $tileX = $request->tileX();
+        $tileY = $request->tileY();
+        $from = $request->startTime();
+        $to = $request->endTime($from);
+        $horizon = $request->horizonHours();
+
+        $resolution = $this->resolutionForZoom($zoom);
+        $boundingBox = $this->tileBoundingBox($tileX, $tileY, $zoom);
+
+        $cacheKey = $this->buildCacheKey($zoom, $tileX, $tileY, $resolution, $from, $to, $horizon);
+
+        $payload = Cache::remember(
+            $cacheKey,
+            now()->addMinutes(self::CACHE_TTL_MINUTES),
+            function () use ($aggregationService, $geometryService, $boundingBox, $resolution, $from, $to, $horizon) {
+                $aggregates = $aggregationService->aggregateByBoundingBox($boundingBox, $resolution, $from, $to, null);
+
+                $cells = [];
+                $maxCount = 0;
+
+                foreach ($aggregates as $aggregate) {
+                    $polygon = $geometryService->polygonCoordinates($aggregate->h3Index);
+                    $centroid = $this->polygonCentroid($polygon);
+
+                    $cells[] = [
+                        'h3' => $aggregate->h3Index,
+                        'count' => $aggregate->count,
+                        'categories' => $aggregate->categories,
+                        'centroid' => [
+                            'lat' => round($centroid[1], 6),
+                            'lng' => round($centroid[0], 6),
+                        ],
+                        'polygon' => array_map(
+                            static fn (array $vertex): array => [
+                                'lng' => round($vertex[0], 6),
+                                'lat' => round($vertex[1], 6),
+                            ],
+                            $polygon
+                        ),
+                    ];
+
+                    $maxCount = max($maxCount, $aggregate->count);
+                }
+
+                return [
+                    'meta' => [
+                        'bounds' => [
+                            'west' => $boundingBox[0],
+                            'south' => $boundingBox[1],
+                            'east' => $boundingBox[2],
+                            'north' => $boundingBox[3],
+                        ],
+                        'max_count' => $maxCount,
+                        'timeframe' => [
+                            'from' => $from?->toIso8601String(),
+                            'to' => $to?->toIso8601String(),
+                        ],
+                        'horizon_hours' => $horizon,
+                    ],
+                    'cells' => $cells,
+                ];
+            }
+        );
+
+        return response()->json([
+            'z' => $zoom,
+            'x' => $tileX,
+            'y' => $tileY,
+            'resolution' => $resolution,
+            'meta' => $payload['meta'],
+            'cells' => $payload['cells'],
+        ]);
+    }
+
+    /**
+     * Determine the H3 resolution to use for the supplied zoom level.
+     */
+    private function resolutionForZoom(int $zoom): int
+    {
+        if ($zoom <= 8) {
+            return 6;
+        }
+
+        if ($zoom <= 11) {
+            return 7;
+        }
+
+        return 8;
+    }
+
+    /**
+     * Convert tile coordinates into a geographic bounding box.
+     *
+     * @return array{0: float, 1: float, 2: float, 3: float}
+     */
+    private function tileBoundingBox(int $x, int $y, int $z): array
+    {
+        $scale = 1 << $z;
+        $west = $x / $scale * 360 - 180;
+        $east = ($x + 1) / $scale * 360 - 180;
+
+        $north = $this->tileLat($y, $scale);
+        $south = $this->tileLat($y + 1, $scale);
+
+        return [$west, $south, $east, $north];
+    }
+
+    private function tileLat(int $y, int $scale): float
+    {
+        $n = pi() - (2.0 * pi() * $y) / $scale;
+
+        return rad2deg(atan(sinh($n)));
+    }
+
+    /**
+     * Approximate the centroid of a polygon represented as [lng, lat] coordinate pairs.
+     *
+     * @param array<int, array{0: float, 1: float}> $polygon
+     *
+     * @return array{0: float, 1: float}
+     */
+    private function polygonCentroid(array $polygon): array
+    {
+        $points = $polygon;
+
+        if (count($points) > 1) {
+            $first = $points[0];
+            $last = $points[count($points) - 1];
+
+            if ($first[0] === $last[0] && $first[1] === $last[1]) {
+                array_pop($points);
+            }
+        }
+
+        $count = count($points);
+
+        if ($count === 0) {
+            return [0.0, 0.0];
+        }
+
+        if ($count === 1) {
+            return [$points[0][0], $points[0][1]];
+        }
+
+        $area = 0.0;
+        $centroidX = 0.0;
+        $centroidY = 0.0;
+
+        for ($i = 0; $i < $count; $i++) {
+            $current = $points[$i];
+            $next = $points[($i + 1) % $count];
+            $cross = ($current[0] * $next[1]) - ($next[0] * $current[1]);
+            $area += $cross;
+            $centroidX += ($current[0] + $next[0]) * $cross;
+            $centroidY += ($current[1] + $next[1]) * $cross;
+        }
+
+        $area *= 0.5;
+
+        if (abs($area) < 1e-12) {
+            $avgLng = 0.0;
+            $avgLat = 0.0;
+            foreach ($points as $point) {
+                $avgLng += $point[0];
+                $avgLat += $point[1];
+            }
+
+            return [$avgLng / $count, $avgLat / $count];
+        }
+
+        $factor = 1 / (6 * $area);
+
+        return [$centroidX * $factor, $centroidY * $factor];
+    }
+
+    private function buildCacheKey(
+        int $zoom,
+        int $x,
+        int $y,
+        int $resolution,
+        ?CarbonImmutable $from,
+        ?CarbonImmutable $to,
+        ?int $horizon,
+    ): string {
+        $fromKey = $from?->toIso8601String() ?? 'null';
+        $toKey = $to?->toIso8601String() ?? 'null';
+        $horizonKey = $horizon !== null ? (string) $horizon : 'null';
+
+        $rawKey = implode('|', [
+            $zoom,
+            $x,
+            $y,
+            $resolution,
+            $fromKey,
+            $toKey,
+            $horizonKey,
+        ]);
+
+        $version = Cache::get(H3AggregationService::CACHE_VERSION_KEY, 1);
+
+        return sprintf('%s%d:%s', self::CACHE_PREFIX, $version, md5($rawKey));
+    }
+}

--- a/backend/app/Http/Requests/HeatmapTileRequest.php
+++ b/backend/app/Http/Requests/HeatmapTileRequest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\ValidationException;
+
+class HeatmapTileRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'z' => ['required', 'integer', 'between:0,22'],
+            'x' => ['required', 'integer', 'min:0'],
+            'y' => ['required', 'integer', 'min:0'],
+            'ts_start' => ['nullable', 'date'],
+            'ts_end' => ['nullable', 'date', 'after_or_equal:ts_start'],
+            'horizon' => ['nullable', 'integer', 'min:0', 'max:336'],
+        ];
+    }
+
+    public function validationData(): array
+    {
+        $route = $this->route();
+        $parameters = method_exists($route, 'parametersWithoutNulls')
+            ? $route->parametersWithoutNulls()
+            : ($route?->parameters() ?? []);
+
+        return array_merge(parent::validationData(), $parameters);
+    }
+
+    protected function passedValidation(): void
+    {
+        $zoom = $this->zoom();
+        $maxIndex = 1 << $zoom;
+
+        if ($this->tileX() >= $maxIndex || $this->tileY() >= $maxIndex) {
+            throw ValidationException::withMessages([
+                'tile' => ['Tile coordinates are outside the valid range for this zoom level.'],
+            ]);
+        }
+    }
+
+    public function zoom(): int
+    {
+        return (int) ($this->input('z') ?? $this->route('z'));
+    }
+
+    public function tileX(): int
+    {
+        return (int) ($this->input('x') ?? $this->route('x'));
+    }
+
+    public function tileY(): int
+    {
+        return (int) ($this->input('y') ?? $this->route('y'));
+    }
+
+    public function horizonHours(): ?int
+    {
+        $value = $this->input('horizon');
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    public function startTime(): ?CarbonImmutable
+    {
+        $value = $this->input('ts_start');
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return new CarbonImmutable($value);
+    }
+
+    public function endTime(?CarbonImmutable $start = null): ?CarbonImmutable
+    {
+        $value = $this->input('ts_end');
+
+        if ($value !== null && $value !== '') {
+            return new CarbonImmutable($value);
+        }
+
+        $horizon = $this->horizonHours();
+
+        if ($start && $horizon !== null && $horizon > 0) {
+            return $start->addHours($horizon);
+        }
+
+        return null;
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\v1\AuthController;
 use App\Http\Controllers\Api\v1\DatasetController;
 use App\Http\Controllers\Api\v1\ExportController;
 use App\Http\Controllers\Api\v1\HealthController;
+use App\Http\Controllers\Api\v1\HeatmapTileController;
 use App\Http\Controllers\Api\v1\HexController;
 use App\Http\Controllers\Api\v1\ModelController;
 use App\Http\Controllers\Api\v1\NlqController;
@@ -35,6 +36,7 @@ Route::prefix('v1')->group(function () use ($authRoutes): void {
     Route::middleware('auth.api')->group(function (): void {
         Route::get('/hexes', [HexController::class, 'index']);
         Route::get('/hexes/geojson', [HexController::class, 'geoJson']);
+        Route::get('/heatmap/{z}/{x}/{y}', HeatmapTileController::class);
 
         Route::get('/export', ExportController::class);
 

--- a/backend/tests/Feature/HeatmapTileApiTest.php
+++ b/backend/tests/Feature/HeatmapTileApiTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Models\Crime;
+use App\Services\H3GeometryService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Mockery;
+use Tests\TestCase;
+
+class HeatmapTileApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_tile_payload_with_time_filters(): void
+    {
+        Crime::factory()->create([
+            'category' => 'burglary',
+            'occurred_at' => Carbon::parse('2024-03-01 10:00:00'),
+            'lat' => 53.4,
+            'lng' => -2.9,
+            'h3_res7' => '87283080dffffff',
+        ]);
+
+        Crime::factory()->create([
+            'category' => 'burglary',
+            'occurred_at' => Carbon::parse('2024-03-01 18:00:00'),
+            'lat' => 53.405,
+            'lng' => -2.905,
+            'h3_res7' => '87283080dffffff',
+        ]);
+
+        // Outside the requested horizon window and should be excluded
+        Crime::factory()->create([
+            'category' => 'burglary',
+            'occurred_at' => Carbon::parse('2024-03-04 09:00:00'),
+            'lat' => 53.401,
+            'lng' => -2.902,
+            'h3_res7' => '87283080dffffff',
+        ]);
+
+        // Outside the tile bounds entirely
+        Crime::factory()->create([
+            'category' => 'theft',
+            'occurred_at' => Carbon::parse('2024-03-01 11:00:00'),
+            'lat' => 51.5,
+            'lng' => -0.12,
+            'h3_res7' => '8702a5fffffffff',
+        ]);
+
+        $mock = Mockery::mock(H3GeometryService::class);
+        $mock->shouldReceive('polygonCoordinates')
+            ->once()
+            ->andReturn([[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]]);
+
+        $this->app->instance(H3GeometryService::class, $mock);
+
+        $tokens = $this->issueTokensForRole(Role::Viewer);
+
+        $response = $this->withToken($tokens['accessToken'])
+            ->getJson('/api/v1/heatmap/9/251/165?ts_start=2024-03-01T00:00:00Z&horizon=48');
+
+        $response->assertOk()
+            ->assertJsonPath('meta.max_count', 2)
+            ->assertJsonPath('meta.timeframe.from', '2024-03-01T00:00:00+00:00')
+            ->assertJsonPath('meta.timeframe.to', '2024-03-03T00:00:00+00:00')
+            ->assertJsonPath('cells.0.count', 2)
+            ->assertJsonPath('cells.0.h3', '87283080dffffff')
+            ->assertJsonStructure([
+                'z',
+                'x',
+                'y',
+                'resolution',
+                'meta' => [
+                    'bounds' => ['west', 'south', 'east', 'north'],
+                    'max_count',
+                    'timeframe' => ['from', 'to'],
+                    'horizon_hours',
+                ],
+                'cells' => [[
+                    'h3',
+                    'count',
+                    'categories',
+                    'centroid' => ['lat', 'lng'],
+                    'polygon',
+                ]],
+            ]);
+    }
+
+    public function test_rejects_out_of_range_tiles(): void
+    {
+        $tokens = $this->issueTokensForRole(Role::Viewer);
+
+        $this->withToken($tokens['accessToken'])
+            ->getJson('/api/v1/heatmap/2/8/1')
+            ->assertStatus(422);
+    }
+
+    public function test_requests_without_token_are_rejected(): void
+    {
+        $this->getJson('/api/v1/heatmap/9/251/165')
+            ->assertUnauthorized();
+    }
+}

--- a/frontend/src/views/PredictView.vue
+++ b/frontend/src/views/PredictView.vue
@@ -24,6 +24,7 @@
                         :center="mapCenter"
                         :points="predictionStore.heatmapPoints"
                         :radius-km="predictionStore.lastFilters.radiusKm"
+                        :tile-options="heatmapTileOptions"
                     />
                 </template>
                 <template #fallback>
@@ -115,6 +116,19 @@ const MapView = defineAsyncComponent(() => import('../components/map/MapView.vue
 const predictionStore = usePredictionStore()
 
 const mapCenter = computed(() => predictionStore.currentPrediction?.filters?.center ?? predictionStore.lastFilters.center)
+
+const heatmapTileOptions = computed(() => {
+    const options = {}
+    const tsStart = predictionStore.lastFilters.timestamp
+    if (tsStart) {
+        options.tsStart = tsStart
+    }
+    const horizon = Number(predictionStore.lastFilters.horizon)
+    if (Number.isFinite(horizon) && horizon >= 0) {
+        options.horizon = horizon
+    }
+    return options
+})
 
 const predictionSummary = computed(() => ({
     generatedAt: predictionStore.currentPrediction?.generatedAt,


### PR DESCRIPTION
## Summary
- add an authenticated /api/heatmap/{z}/{x}/{y} endpoint with tile-aware caching, validation, and polygon centroid metadata
- expose a HeatmapTileRequest and feature tests covering filtering, validation, and auth behaviours
- replace the Leaflet heatmap marker overlay with an XYZ tile grid layer that fetches the new API using configurable timestamp and horizon filters, plus wire PredictView to supply those filters
- document the versioned heatmap tile API path in the backend README