### PR TITLE
Improve police crime ingestion pipeline

### DIFF
--- a/backend/app/DataTransferObjects/CrimeIngestionStats.php
+++ b/backend/app/DataTransferObjects/CrimeIngestionStats.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\DataTransferObjects;
+
+readonly class CrimeIngestionStats
+{
+    public function __construct(
+        public int $recordsDetected,
+        public int $recordsExpected,
+        public int $recordsExisting,
+        public int $recordsDuplicates,
+        public int $recordsInvalid,
+    ) {
+    }
+
+    public function existingRecords(): int
+    {
+        return $this->recordsExisting;
+    }
+
+    public function skippedRecords(): int
+    {
+        return $this->recordsDuplicates + $this->recordsInvalid;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a `CrimeIngestionStats` DTO to track processed, inserted, duplicate, and invalid record counts during ingestion
- enhance the police crime ingestion service to stream archives more reliably, normalise CSV rows, de-duplicate records, and log richer progress/completion metrics
- ensure downloads return the correct DTO type and maintain deterministic IDs plus JSON payload encoding for raw data