### PR TITLE
feat: surface dataset uploads and listing endpoint

### DIFF
--- a/backend/app/Http/Requests/DatasetIngestRequest.php
+++ b/backend/app/Http/Requests/DatasetIngestRequest.php
@@ -7,10 +7,40 @@ use App\Rules\ValidGeoJson;
 use App\Support\ResolvesRoles;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use function pathinfo;
+use const PATHINFO_FILENAME;
+use JsonException;
 
 class DatasetIngestRequest extends FormRequest
 {
     use ResolvesRoles;
+
+    protected function prepareForValidation(): void
+    {
+        $this->decodeJsonArrayInput('metadata');
+        $this->decodeJsonArrayInput('schema');
+
+        if (! $this->filled('name')) {
+            $file = $this->file('file');
+
+            if ($file !== null) {
+                $originalName = $file->getClientOriginalName() ?? '';
+                $inferredName = (string) pathinfo($originalName, PATHINFO_FILENAME);
+
+                if ($inferredName === '' && $originalName !== '') {
+                    $inferredName = $originalName;
+                }
+
+                if ($inferredName !== '') {
+                    $this->merge(['name' => substr($inferredName, 0, 255)]);
+                }
+            }
+        }
+
+        if (! $this->filled('source_type') && $this->file('file') !== null) {
+            $this->merge(['source_type' => 'file']);
+        }
+    }
 
     public function authorize(): bool
     {
@@ -42,5 +72,24 @@ class DatasetIngestRequest extends FormRequest
             'source_uri' => ['required_if:source_type,url', 'url'],
             'metadata' => ['nullable', 'array'],
         ];
+    }
+
+    private function decodeJsonArrayInput(string $key): void
+    {
+        $value = $this->input($key);
+
+        if (! is_string($value) || trim($value) === '') {
+            return;
+        }
+
+        try {
+            $decoded = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return;
+        }
+
+        if (is_array($decoded)) {
+            $this->merge([$key => $decoded]);
+        }
     }
 }

--- a/backend/config/api.php
+++ b/backend/config/api.php
@@ -13,8 +13,11 @@ return [
         'ingest' => (int) env('API_PAYLOAD_MAX_KB', 20_480),
         'predict' => (int) env('API_PREDICT_MAX_KB', 10_240),
     ],
-    'allowed_ingest_mimes' => array_values(array_filter(array_map(
+    'allowed_ingest_mimes' => array_values(array_unique(array_filter(array_map(
         static fn (string $mime): string => trim($mime),
-        explode(',', (string) env('API_ALLOWED_INGEST_MIMES', 'text/csv,application/json,application/geo+json'))
-    ))),
+        explode(',', (string) env(
+            'API_ALLOWED_INGEST_MIMES',
+            'text/csv,text/plain,application/vnd.ms-excel,application/json,application/geo+json'
+        ))
+    )))),
 ];

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -24,16 +24,24 @@ $authRoutes = function (): void {
     });
 };
 
-// Unversioned auth routes
+/**
+ * Unversioned auth routes
+ */
 Route::prefix('auth')->group($authRoutes);
 
-// Versioned API routes
+/**
+ * Versioned API routes
+ */
 Route::prefix('v1')->group(function () use ($authRoutes): void {
     Route::prefix('auth')->group($authRoutes);
 
     Route::get('/health', HealthController::class);
 
     Route::middleware('auth.api')->group(function (): void {
+        Route::get('/datasets', [DatasetController::class, 'index']);
+        Route::get('/datasets/runs', [DatasetController::class, 'runs']);
+        Route::post('/datasets/ingest', [DatasetController::class, 'ingest']);
+
         Route::get('/hexes', [HexController::class, 'index']);
         Route::get('/hexes/geojson', [HexController::class, 'geoJson']);
         Route::get('/heatmap/{z}/{x}/{y}', HeatmapTileController::class);
@@ -41,9 +49,6 @@ Route::prefix('v1')->group(function () use ($authRoutes): void {
         Route::get('/export', ExportController::class);
 
         Route::post('/nlq', NlqController::class);
-
-        Route::post('/datasets/ingest', [DatasetController::class, 'ingest']);
-        Route::get('/datasets/runs', [DatasetController::class, 'runs']);
 
         Route::get('/models', [ModelController::class, 'index']);
         Route::get('/models/{id}', [ModelController::class, 'show']);

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -33,6 +33,8 @@ server {
   server_name _;
   root /var/www/html/public;
 
+  client_max_body_size 10m;
+
   index index.php;
 
   location / {

--- a/frontend/src/components/dataset/DatasetIngest.vue
+++ b/frontend/src/components/dataset/DatasetIngest.vue
@@ -117,7 +117,7 @@ const props = defineProps({
     },
 })
 
-const emit = defineEmits(['update:modelValue'])
+const emit = defineEmits(['update:modelValue', 'submitted'])
 
 const datasetStore = useDatasetStore()
 const { step } = storeToRefs(datasetStore)
@@ -164,8 +164,9 @@ function close() {
 }
 
 async function submit() {
-    const success = await datasetStore.submitIngestion({ submittedAt: new Date().toISOString() })
-    if (success) {
+    const result = await datasetStore.submitIngestion({ submittedAt: new Date().toISOString() })
+    if (result) {
+        emit('submitted', result)
         close()
     }
 }

--- a/frontend/src/stores/dataset.js
+++ b/frontend/src/stores/dataset.js
@@ -84,10 +84,10 @@ export const useDatasetStore = defineStore('dataset', {
                 formData.append('file', this.uploadFile)
                 formData.append('schema', JSON.stringify(this.schemaMapping))
                 formData.append('metadata', JSON.stringify(payload))
-                await apiClient.post('/datasets/ingest', formData)
+                const { data } = await apiClient.post('/datasets/ingest', formData)
                 notifySuccess({ title: 'Dataset queued', message: 'Ingestion pipeline started successfully.' })
                 this.reset()
-                return true
+                return data
             } catch (error) {
                 notifyError(error, 'Dataset ingestion failed to start.')
                 return false


### PR DESCRIPTION
## Summary
- add a paginated `/api/v1/datasets` endpoint that supports sorting and filtering and includes feature counts
- include the feature count in ingest responses and cover the new listing behaviour with a feature test
- refresh the admin datasets view to show recent uploads, refresh automatically, and react to wizard submissions