### PR TITLE
updated csv import to correctly correlate data

### DIFF
--- a/backend/app/Http/Controllers/Api/v1/DatasetController.php
+++ b/backend/app/Http/Controllers/Api/v1/DatasetController.php
@@ -10,28 +10,35 @@ use App\Http\Requests\DatasetIngestRequest;
 use App\Models\CrimeIngestionRun;
 use App\Models\Dataset;
 use App\Models\User;
+use App\Services\DatasetPreviewService;
 use App\Support\InteractsWithPagination;
 use App\Support\ResolvesRoles;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 class DatasetController extends Controller
 {
     use ResolvesRoles;
     use InteractsWithPagination;
 
-    public function __construct()
+    public function __construct(private readonly DatasetPreviewService $previewService)
     {
         $this->middleware(['auth.api', 'throttle:api']);
     }
 
     /**
      * List recently uploaded datasets.
+     *
+     * @throws AuthorizationException
      */
     public function index(Request $request): JsonResponse
     {
@@ -101,7 +108,7 @@ class DatasetController extends Controller
      *
      * @param DatasetIngestRequest $request
      *
-     * @return JsonResponse*
+     * @return JsonResponse
      * @throws AuthorizationException
      */
     public function ingest(DatasetIngestRequest $request): JsonResponse
@@ -123,6 +130,8 @@ class DatasetController extends Controller
             'created_by' => $createdBy,
         ]);
 
+        $preview = null;
+
         if ($request->file('file') !== null) {
             $file = $request->file('file');
             $fileName = sprintf('%s.%s', Str::uuid(), $file->getClientOriginalExtension());
@@ -132,8 +141,43 @@ class DatasetController extends Controller
             $dataset->checksum = hash_file('sha256', $file->getRealPath());
         }
 
+        try {
+            $preview = $this->previewService->summarise(
+                Storage::disk('local')->path($path),
+                $dataset->mime_type
+            );
+        } catch (Throwable $exception) {
+            Log::warning('Failed to generate dataset preview', [
+                'dataset_id' => $dataset->id,
+                'path' => $path,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+
         $dataset->save();
         $dataset->refresh();
+
+        if ($preview !== null) {
+            $metadata = $dataset->metadata ?? [];
+
+            if (!is_array($metadata)) {
+                $metadata = [];
+            }
+
+            $metadata = array_replace($metadata, array_filter([
+                'row_count' => $preview['row_count'] ?? 0,
+                'preview_rows' => $preview['preview_rows'] ?? [],
+                'headers' => $preview['headers'] ?? [],
+            ], static function ($value) {
+                if (is_array($value)) {
+                    return $value !== [];
+                }
+
+                return $value !== null;
+            }));
+
+            $dataset->metadata = $metadata;
+        }
 
         $dataset->status = DatasetStatus::Ready;
         $dataset->ingested_at = now();
@@ -270,16 +314,24 @@ class DatasetController extends Controller
 
     private function resolveFeaturesCount(Dataset $dataset): int
     {
+        $metadataCount = (int) Arr::get($dataset->metadata ?? [], 'row_count', 0);
+
         if (!$this->featuresTableExists()) {
-            return 0;
+            return $metadataCount;
         }
 
         $count = $dataset->getAttribute('features_count');
 
-        if ($count !== null) {
+        if ($count !== null && (int) $count > 0) {
             return (int) $count;
         }
 
-        return (int) $dataset->features()->count();
+        $relationCount = (int) $dataset->features()->count();
+
+        if ($relationCount > 0) {
+            return $relationCount;
+        }
+
+        return $metadataCount;
     }
 }

--- a/backend/app/Services/DatasetPreviewService.php
+++ b/backend/app/Services/DatasetPreviewService.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Str;
+use RuntimeException;
+use function array_is_list;
+
+class DatasetPreviewService
+{
+    private const PREVIEW_LIMIT = 5;
+
+    /**
+     * Generate a small summary of the supplied dataset file, including the row count and a preview of the
+     * first few rows. The service currently supports CSV and JSON/GeoJSON payloads.
+     *
+     * @return array{headers: list<string>, row_count: int, preview_rows: list<array<string, mixed>>}
+     */
+    public function summarise(string $path, ?string $mimeType = null): array
+    {
+        $mimeType = $mimeType !== null ? strtolower($mimeType) : null;
+
+        if ($mimeType !== null && str_contains($mimeType, 'json')) {
+            return $this->summariseJson($path);
+        }
+
+        $extension = strtolower((string) pathinfo($path, PATHINFO_EXTENSION));
+
+        if ($extension === 'json' || $extension === 'geojson') {
+            return $this->summariseJson($path);
+        }
+
+        return $this->summariseCsv($path);
+    }
+
+    /**
+     * @return array{headers: list<string>, row_count: int, preview_rows: list<array<string, mixed>>}
+     */
+    private function summariseCsv(string $path): array
+    {
+        $handle = fopen($path, 'rb');
+
+        if ($handle === false) {
+            throw new RuntimeException(sprintf('Unable to open dataset file "%s" for preview generation.', $path));
+        }
+
+        $headers = null;
+        $rowCount = 0;
+        $preview = [];
+
+        try {
+            while (($row = fgetcsv($handle)) !== false) {
+                if ($headers === null) {
+                    $headers = $this->normaliseHeaders($row);
+
+                    if ($headers === []) {
+                        break;
+                    }
+
+                    continue;
+                }
+
+                if ($this->isEmptyRow($row)) {
+                    continue;
+                }
+
+                $assoc = $this->combineRow($headers, $row);
+
+                if ($assoc === null || $assoc === []) {
+                    continue;
+                }
+
+                $rowCount++;
+
+                if (count($preview) < self::PREVIEW_LIMIT) {
+                    $preview[] = $assoc;
+                }
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        return [
+            'headers' => $headers ?? [],
+            'row_count' => $rowCount,
+            'preview_rows' => $preview,
+        ];
+    }
+
+    /**
+     * @return array{headers: list<string>, row_count: int, preview_rows: list<array<string, mixed>>}
+     */
+    private function summariseJson(string $path): array
+    {
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            throw new RuntimeException(sprintf('Unable to read dataset file "%s" for preview generation.', $path));
+        }
+
+        try {
+            $decoded = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [
+                'headers' => [],
+                'row_count' => 0,
+                'preview_rows' => [],
+            ];
+        }
+
+        if (is_array($decoded)) {
+            if (array_key_exists('type', $decoded) && Str::lower((string) $decoded['type']) === 'featurecollection') {
+                $features = isset($decoded['features']) && is_array($decoded['features']) ? $decoded['features'] : [];
+
+                $rows = [];
+
+                foreach ($features as $feature) {
+                    if (!is_array($feature)) {
+                        continue;
+                    }
+
+                    $rows[] = [
+                        'type' => $feature['type'] ?? null,
+                        'properties' => $feature['properties'] ?? null,
+                        'geometry' => $feature['geometry'] ?? null,
+                    ];
+                }
+
+                return [
+                    'headers' => ['type', 'properties', 'geometry'],
+                    'row_count' => count($rows),
+                    'preview_rows' => array_slice($rows, 0, self::PREVIEW_LIMIT),
+                ];
+            }
+
+            if (array_is_list($decoded)) {
+                $rows = [];
+
+                foreach ($decoded as $entry) {
+                    if (is_array($entry)) {
+                        $rows[] = $entry;
+                    } else {
+                        $rows[] = ['value' => $entry];
+                    }
+                }
+
+                $preview = array_slice($rows, 0, self::PREVIEW_LIMIT);
+
+                $headers = $preview !== [] ? array_keys($preview[0]) : [];
+
+                return [
+                    'headers' => $headers,
+                    'row_count' => count($rows),
+                    'preview_rows' => $preview,
+                ];
+            }
+
+            return [
+                'headers' => array_keys($decoded),
+                'row_count' => 1,
+                'preview_rows' => [$decoded],
+            ];
+        }
+
+        return [
+            'headers' => [],
+            'row_count' => 0,
+            'preview_rows' => [],
+        ];
+    }
+
+    /**
+     * @param array<int, string|null> $headers
+     * @return list<string>
+     */
+    private function normaliseHeaders(array $headers): array
+    {
+        $normalised = [];
+
+        foreach ($headers as $header) {
+            if ($header === null) {
+                $normalised[] = '';
+                continue;
+            }
+
+            $value = preg_replace('/^\xEF\xBB\xBF/', '', $header);
+            $value = trim((string) $value);
+
+            $normalised[] = $value;
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * @param array<int, string|null> $row
+     */
+    private function isEmptyRow(array $row): bool
+    {
+        foreach ($row as $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            if (trim((string) $value) !== '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param list<string> $headers
+     * @param array<int, string|null> $row
+     * @return array<string, string|null>|null
+     */
+    private function combineRow(array $headers, array $row): ?array
+    {
+        if ($headers === []) {
+            return null;
+        }
+
+        $assoc = [];
+
+        foreach ($headers as $index => $header) {
+            if ($header === '') {
+                continue;
+            }
+
+            $value = $row[$index] ?? null;
+
+            if (is_string($value)) {
+                $value = trim($value);
+            }
+
+            $assoc[$header] = $value;
+        }
+
+        foreach ($assoc as $value) {
+            if ($value !== null && ($value !== '')) {
+                return $assoc;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Added a DatasetPreviewService that extracts headers, row counts, and preview rows from uploaded CSV or JSON/GeoJSON files to provide quick dataset snapshots.

Updated DatasetController to generate previews during ingestion, merge the snapshot into stored metadata, and fall back to metadata row counts when feature records are absent.

Refined dataset API tests to supply real CSV content and assert the new preview metadata and record counts returned by the ingest endpoint.