### PR TITLE
Enable admin model creation and training flow

### DIFF
--- a/backend/app/Http/Controllers/Api/v1/ModelController.php
+++ b/backend/app/Http/Controllers/Api/v1/ModelController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\v1;
 use App\Enums\ModelStatus;
 use App\Enums\TrainingStatus;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\CreateModelRequest;
 use App\Http\Requests\EvaluateModelRequest;
 use App\Http\Requests\TrainModelRequest;
 use App\Jobs\EvaluateModelJob;
@@ -79,6 +80,37 @@ class ModelController extends Controller
             $models,
             fn (PredictiveModel $model) => $this->transform($model)
         ));
+    }
+
+    public function store(CreateModelRequest $request): JsonResponse
+    {
+        $this->authorize('create', PredictiveModel::class);
+
+        $validated = $request->validated();
+
+        $model = new PredictiveModel();
+        $model->id = (string) Str::uuid();
+        $model->name = $validated['name'];
+        $model->dataset_id = $validated['dataset_id'] ?? null;
+        $model->version = $validated['version'] ?? '1.0.0';
+        $model->tag = $validated['tag'] ?? null;
+        $model->area = $validated['area'] ?? null;
+        $model->hyperparameters = $validated['hyperparameters'] ?? null;
+        $model->metadata = $validated['metadata'] ?? null;
+
+        $user = $request->user();
+
+        if ($user instanceof User) {
+            $model->created_by = $user->getKey();
+        }
+
+        $model->save();
+
+        $model = $model->fresh(['trainingRuns']);
+
+        return response()->json([
+            'data' => $this->transform($model),
+        ], JsonResponse::HTTP_CREATED);
     }
 
     public function show(string $id): JsonResponse

--- a/backend/app/Http/Controllers/Api/v1/ModelController.php
+++ b/backend/app/Http/Controllers/Api/v1/ModelController.php
@@ -16,6 +16,7 @@ use App\Models\User;
 use App\Services\IdempotencyService;
 use App\Services\ModelStatusService;
 use App\Support\InteractsWithPagination;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -82,6 +83,9 @@ class ModelController extends Controller
         ));
     }
 
+    /**
+     * @throws AuthorizationException
+     */
     public function store(CreateModelRequest $request): JsonResponse
     {
         $this->authorize('create', PredictiveModel::class);

--- a/backend/app/Http/Requests/CreateModelRequest.php
+++ b/backend/app/Http/Requests/CreateModelRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Support\ResolvesRoles;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class CreateModelRequest extends FormRequest
+{
+    use ResolvesRoles;
+
+    public function authorize(): bool
+    {
+        $role = $this->resolveRole($this->user());
+
+        return $role->canManageModels();
+    }
+
+    /**
+     * @return array<string, array<int, string|Rule>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'dataset_id' => ['nullable', 'uuid', Rule::exists('datasets', 'id')],
+            'version' => ['nullable', 'string', 'max:50'],
+            'tag' => ['nullable', 'string', 'max:100'],
+            'area' => ['nullable', 'string', 'max:255'],
+            'hyperparameters' => ['nullable', 'array'],
+            'metadata' => ['nullable', 'array'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'dataset_id' => $this->nullifyEmptyString('dataset_id'),
+            'version' => $this->nullifyEmptyString('version'),
+            'tag' => $this->nullifyEmptyString('tag'),
+            'area' => $this->nullifyEmptyString('area'),
+        ]);
+    }
+
+    private function nullifyEmptyString(string $key): ?string
+    {
+        $value = $this->input($key);
+
+        if (is_string($value) && trim($value) === '') {
+            return null;
+        }
+
+        return $value;
+    }
+}

--- a/backend/app/Http/Requests/CreateModelRequest.php
+++ b/backend/app/Http/Requests/CreateModelRequest.php
@@ -24,7 +24,7 @@ class CreateModelRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'dataset_id' => ['nullable', 'uuid', Rule::exists('datasets', 'id')],
+            'dataset_id' => ['required', 'uuid', Rule::exists('datasets', 'id')],
             'version' => ['nullable', 'string', 'max:50'],
             'tag' => ['nullable', 'string', 'max:100'],
             'area' => ['nullable', 'string', 'max:255'],
@@ -47,8 +47,14 @@ class CreateModelRequest extends FormRequest
     {
         $value = $this->input($key);
 
-        if (is_string($value) && trim($value) === '') {
-            return null;
+        if (is_string($value)) {
+            $value = trim($value);
+
+            if ($value === '') {
+                return null;
+            }
+
+            return $value;
         }
 
         return $value;

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -51,6 +51,7 @@ Route::prefix('v1')->group(function () use ($authRoutes): void {
         Route::post('/nlq', NlqController::class);
 
         Route::get('/models', [ModelController::class, 'index']);
+        Route::post('/models', [ModelController::class, 'store']);
         Route::get('/models/{id}', [ModelController::class, 'show']);
         Route::get('/models/{id}/status', [ModelController::class, 'status']);
         Route::post('/models/train', [ModelController::class, 'train']);

--- a/backend/tests/Feature/ModelApiTest.php
+++ b/backend/tests/Feature/ModelApiTest.php
@@ -7,6 +7,7 @@ use App\Enums\Role;
 use App\Events\ModelStatusUpdated;
 use App\Jobs\EvaluateModelJob;
 use App\Jobs\TrainModelJob;
+use App\Models\Dataset;
 use App\Models\PredictiveModel;
 use App\Models\TrainingRun;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -19,6 +20,52 @@ use Tests\TestCase;
 class ModelApiTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function test_admin_can_create_model(): void
+    {
+        $dataset = Dataset::factory()->create();
+        $tokens = $this->issueTokensForRole(Role::Admin);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])
+            ->postJson('/api/v1/models', [
+                'name' => 'Spatial Graph Attention',
+                'dataset_id' => $dataset->id,
+                'version' => '2.0.0',
+                'tag' => 'baseline',
+                'area' => 'Downtown',
+                'hyperparameters' => ['learning_rate' => 0.05],
+                'metadata' => ['notes' => 'Initial run'],
+            ]);
+
+        $response->assertCreated();
+        $response->assertJsonPath('data.name', 'Spatial Graph Attention');
+        $response->assertJsonPath('data.dataset_id', $dataset->id);
+        $response->assertJsonPath('data.status', ModelStatus::Draft->value);
+
+        $this->assertDatabaseHas('models', [
+            'name' => 'Spatial Graph Attention',
+            'dataset_id' => $dataset->id,
+            'version' => '2.0.0',
+            'tag' => 'baseline',
+            'area' => 'Downtown',
+        ]);
+    }
+
+    public function test_non_admin_cannot_create_model(): void
+    {
+        $tokens = $this->issueTokensForRole(Role::Analyst);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])
+            ->postJson('/api/v1/models', [
+                'name' => 'Unauthorized Model',
+            ]);
+
+        $response->assertForbidden();
+
+        $this->assertDatabaseMissing('models', [
+            'name' => 'Unauthorized Model',
+        ]);
+    }
 
     public function test_training_request_dispatches_job(): void
     {

--- a/backend/tests/Feature/ModelApiTest.php
+++ b/backend/tests/Feature/ModelApiTest.php
@@ -67,6 +67,23 @@ class ModelApiTest extends TestCase
         ]);
     }
 
+    public function test_dataset_is_required_when_creating_model(): void
+    {
+        $tokens = $this->issueTokensForRole(Role::Admin);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])
+            ->postJson('/api/v1/models', [
+                'name' => 'Missing Dataset Model',
+            ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['dataset_id']);
+
+        $this->assertDatabaseMissing('models', [
+            'name' => 'Missing Dataset Model',
+        ]);
+    }
+
     public function test_training_request_dispatches_job(): void
     {
         Bus::fake();

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -116,6 +116,7 @@
 
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
 import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router'
 import AppToaster from './components/feedback/AppToaster.vue'
 import { useAuthStore } from './stores/auth'
@@ -125,10 +126,9 @@ const route = useRoute()
 const router = useRouter()
 const mainElement = ref(null)
 
-const isAdmin = computed(() => authStore.isAdmin)
-const isAuthenticated = computed(() => authStore.isAuthenticated)
-const userName = computed(() => authStore.user?.name ?? 'Guest')
-const roleLabel = computed(() => authStore.role.toUpperCase())
+const { isAdmin, isAuthenticated, role, user } = storeToRefs(authStore)
+const userName = computed(() => user.value?.name ?? 'Guest')
+const roleLabel = computed(() => (role.value ?? '').toUpperCase())
 const showChrome = computed(() => isAuthenticated.value && route.name !== 'login')
 
 const primaryLinks = [

--- a/frontend/src/components/models/CreateModelModal.vue
+++ b/frontend/src/components/models/CreateModelModal.vue
@@ -1,0 +1,338 @@
+<template>
+    <Teleport to="body" v-if="open">
+        <div
+            class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-4 py-8"
+            role="dialog"
+            aria-modal="true"
+        >
+            <div class="w-full max-w-2xl overflow-hidden rounded-2xl bg-white shadow-xl">
+                <header class="flex items-start justify-between gap-4 border-b border-slate-200 px-6 py-4">
+                    <div>
+                        <h2 class="text-lg font-semibold text-slate-900">Create a new model</h2>
+                        <p class="mt-1 text-sm text-slate-600">
+                            Provide the model details and optionally queue an initial training run right away.
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        class="rounded-md border border-transparent p-1 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700"
+                        @click="close"
+                    >
+                        <span class="sr-only">Close</span>
+                        ✕
+                    </button>
+                </header>
+                <form @submit.prevent="submit" class="space-y-6 px-6 py-6">
+                    <div>
+                        <label for="model-name" class="block text-sm font-medium text-slate-700">Model name</label>
+                        <input
+                            id="model-name"
+                            v-model="form.name"
+                            type="text"
+                            name="name"
+                            class="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            placeholder="e.g. Spatial Graph Attention"
+                            autocomplete="off"
+                        />
+                        <p v-if="errors.name" class="mt-1 text-sm text-rose-600">{{ errors.name }}</p>
+                    </div>
+                    <div class="grid gap-4 sm:grid-cols-2">
+                        <div>
+                            <label for="dataset-id" class="block text-sm font-medium text-slate-700">Dataset identifier</label>
+                            <input
+                                id="dataset-id"
+                                v-model="form.datasetId"
+                                type="text"
+                                name="dataset"
+                                class="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                placeholder="Optional dataset ID"
+                                autocomplete="off"
+                            />
+                            <p v-if="errors.datasetId" class="mt-1 text-sm text-rose-600">{{ errors.datasetId }}</p>
+                        </div>
+                        <div>
+                            <label for="model-tag" class="block text-sm font-medium text-slate-700">Tag</label>
+                            <input
+                                id="model-tag"
+                                v-model="form.tag"
+                                type="text"
+                                name="tag"
+                                class="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                placeholder="Optional tag (e.g. baseline)"
+                                autocomplete="off"
+                            />
+                            <p v-if="errors.tag" class="mt-1 text-sm text-rose-600">{{ errors.tag }}</p>
+                        </div>
+                        <div>
+                            <label for="model-area" class="block text-sm font-medium text-slate-700">Area</label>
+                            <input
+                                id="model-area"
+                                v-model="form.area"
+                                type="text"
+                                name="area"
+                                class="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                placeholder="Optional geography or scope"
+                                autocomplete="off"
+                            />
+                            <p v-if="errors.area" class="mt-1 text-sm text-rose-600">{{ errors.area }}</p>
+                        </div>
+                        <div>
+                            <label for="model-version" class="block text-sm font-medium text-slate-700">Version</label>
+                            <input
+                                id="model-version"
+                                v-model="form.version"
+                                type="text"
+                                name="version"
+                                class="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                placeholder="Defaults to 1.0.0"
+                                autocomplete="off"
+                            />
+                            <p v-if="errors.version" class="mt-1 text-sm text-rose-600">{{ errors.version }}</p>
+                        </div>
+                    </div>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label for="model-hyperparameters" class="block text-sm font-medium text-slate-700">
+                                Hyperparameters (JSON)
+                            </label>
+                            <textarea
+                                id="model-hyperparameters"
+                                v-model="form.hyperparameters"
+                                name="hyperparameters"
+                                rows="4"
+                                class="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                placeholder='{ "learning_rate": 0.01 }'
+                            ></textarea>
+                            <p v-if="errors.hyperparameters" class="mt-1 text-sm text-rose-600">{{ errors.hyperparameters }}</p>
+                        </div>
+                        <div>
+                            <label for="model-metadata" class="block text-sm font-medium text-slate-700">Metadata (JSON)</label>
+                            <textarea
+                                id="model-metadata"
+                                v-model="form.metadata"
+                                name="metadata"
+                                rows="4"
+                                class="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                placeholder='{ "notes": "First experiment" }'
+                            ></textarea>
+                            <p v-if="errors.metadata" class="mt-1 text-sm text-rose-600">{{ errors.metadata }}</p>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-3 rounded-lg bg-slate-50 px-4 py-3">
+                        <input
+                            id="auto-train"
+                            v-model="form.autoTrain"
+                            type="checkbox"
+                            class="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                        />
+                        <label for="auto-train" class="text-sm text-slate-700">Queue an initial training run after creating the model</label>
+                    </div>
+                    <footer class="flex flex-wrap justify-end gap-3 border-t border-slate-200 pt-4">
+                        <button
+                            type="button"
+                            class="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                            @click="close"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            class="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:bg-slate-400"
+                            :disabled="submitting"
+                        >
+                            <span v-if="submitting">Creating…</span>
+                            <span v-else>Create model</span>
+                        </button>
+                    </footer>
+                </form>
+            </div>
+        </div>
+    </Teleport>
+</template>
+
+<script setup>
+import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
+import { useModelStore } from '../../stores/model'
+
+const props = defineProps({
+    open: {
+        type: Boolean,
+        default: false,
+    },
+})
+
+const emit = defineEmits(['close', 'created'])
+
+const modelStore = useModelStore()
+
+const form = reactive({
+    name: '',
+    datasetId: '',
+    tag: '',
+    area: '',
+    version: '',
+    hyperparameters: '',
+    metadata: '',
+    autoTrain: true,
+})
+
+const errors = reactive({
+    name: '',
+    datasetId: '',
+    tag: '',
+    area: '',
+    version: '',
+    hyperparameters: '',
+    metadata: '',
+})
+
+const training = ref(false)
+
+const submitting = computed(() => modelStore.creating || training.value)
+
+watch(
+    () => props.open,
+    (value) => {
+        if (value) {
+            window.addEventListener('keydown', handleKeydown)
+        } else {
+            window.removeEventListener('keydown', handleKeydown)
+            reset()
+        }
+    },
+)
+
+onBeforeUnmount(() => {
+    window.removeEventListener('keydown', handleKeydown)
+})
+
+function handleKeydown(event) {
+    if (event.key === 'Escape') {
+        close()
+    }
+}
+
+function reset() {
+    form.name = ''
+    form.datasetId = ''
+    form.tag = ''
+    form.area = ''
+    form.version = ''
+    form.hyperparameters = ''
+    form.metadata = ''
+    form.autoTrain = true
+    errors.name = ''
+    errors.datasetId = ''
+    errors.tag = ''
+    errors.area = ''
+    errors.version = ''
+    errors.hyperparameters = ''
+    errors.metadata = ''
+    training.value = false
+}
+
+function close() {
+    emit('close')
+}
+
+function parseJsonField(value, field) {
+    errors[field] = ''
+    if (!value) {
+        return null
+    }
+
+    try {
+        const parsed = JSON.parse(value)
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed
+        }
+        errors[field] = 'Provide a JSON object.'
+    } catch (error) {
+        errors[field] = 'Invalid JSON. Please double-check the structure.'
+    }
+
+    return null
+}
+
+function validate() {
+    let valid = true
+
+    errors.name = form.name.trim() ? '' : 'Model name is required.'
+    if (errors.name) {
+        valid = false
+    }
+
+    errors.tag = ''
+    errors.area = ''
+    errors.version = ''
+
+    if (form.datasetId && form.datasetId.length < 4) {
+        errors.datasetId = 'Dataset identifiers should be at least 4 characters long.'
+        valid = false
+    } else {
+        errors.datasetId = ''
+    }
+
+    const hyperparameters = parseJsonField(form.hyperparameters, 'hyperparameters')
+    const metadata = parseJsonField(form.metadata, 'metadata')
+
+    if (errors.hyperparameters || errors.metadata) {
+        valid = false
+    }
+
+    return { valid, hyperparameters, metadata }
+}
+
+function resolveErrorField(field) {
+    if (!field) {
+        return ''
+    }
+
+    const base = String(field).split('.')[0]
+    return base.replace(/_([a-z])/g, (_, character) => character.toUpperCase())
+}
+
+async function submit() {
+    if (submitting.value) {
+        return
+    }
+
+    const { valid, hyperparameters, metadata } = validate()
+    if (!valid) {
+        return
+    }
+
+    const payload = {
+        name: form.name.trim(),
+        datasetId: form.datasetId.trim() || null,
+        tag: form.tag.trim() || null,
+        area: form.area.trim() || null,
+        version: form.version.trim() || null,
+        hyperparameters: hyperparameters ?? undefined,
+        metadata: metadata ?? undefined,
+    }
+
+    const { model, errors: validationErrors } = await modelStore.createModel(payload)
+
+    if (!model) {
+        if (validationErrors) {
+            Object.entries(validationErrors).forEach(([field, messages]) => {
+                const resolved = resolveErrorField(field)
+                if (resolved in errors) {
+                    errors[resolved] = Array.isArray(messages) ? messages.join(' ') : String(messages)
+                }
+            })
+        }
+        return
+    }
+
+    if (form.autoTrain) {
+        training.value = true
+        await modelStore.trainModel(model.id, hyperparameters ?? undefined)
+        training.value = false
+    }
+
+    emit('created', model)
+    close()
+}
+</script>

--- a/frontend/src/components/models/ModelsTable.vue
+++ b/frontend/src/components/models/ModelsTable.vue
@@ -6,6 +6,14 @@
                 <p class="text-sm text-slate-600">Monitor deployed models and manage retraining cycles.</p>
             </div>
             <div class="flex flex-wrap items-center gap-3">
+                <button
+                    v-if="isAdmin"
+                    class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                    type="button"
+                    @click="$emit('request-create')"
+                >
+                    New model
+                </button>
                 <label class="flex items-center gap-2 text-sm text-slate-600">
                     <span>Status</span>
                     <select
@@ -109,14 +117,17 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref, watch } from 'vue'
+import { onMounted, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
 import PaginationControls from '../common/PaginationControls.vue'
 import { useAuthStore } from '../../stores/auth'
 import { useModelStore } from '../../stores/model'
 
 const authStore = useAuthStore()
 const modelStore = useModelStore()
-const isAdmin = computed(() => authStore.isAdmin)
+const { isAdmin } = storeToRefs(authStore)
+
+defineEmits(['request-create'])
 
 const perPage = 10
 const sortKey = ref('updated_at')

--- a/frontend/src/stores/model.js
+++ b/frontend/src/stores/model.js
@@ -35,6 +35,7 @@ export const useModelStore = defineStore('model', {
         meta: { total: 0, per_page: 15, current_page: 1 },
         links: { first: null, last: null, prev: null, next: null },
         loading: false,
+        creating: false,
         actionState: {},
     }),
     getters: {
@@ -94,10 +95,47 @@ export const useModelStore = defineStore('model', {
             }
             this.links = { first: null, last: null, prev: null, next: null }
         },
-        async trainModel(modelId) {
-            this.actionState = { ...this.actionState, [modelId]: 'training' }
+        async createModel(payload) {
+            this.creating = true
+
+            const body = sanitizeModelPayload(payload)
+
             try {
-                await apiClient.post(`/models/${modelId}/train`)
+                const { data } = await apiClient.post('/models', body)
+                const created = extractModel(data)
+
+                if (created) {
+                    const existingIndex = this.models.findIndex((model) => model.id === created.id)
+                    const remaining = existingIndex === -1 ? this.models : this.models.filter((model) => model.id !== created.id)
+
+                    this.models = [created, ...remaining]
+                    const currentTotal = Number(this.meta?.total ?? 0)
+                    this.meta = {
+                        ...this.meta,
+                        total: existingIndex === -1 ? currentTotal + 1 : currentTotal,
+                        current_page: 1,
+                    }
+                    notifySuccess({ title: 'Model created', message: 'The model has been added to governance.' })
+                }
+
+                return { model: created, errors: null }
+            } catch (error) {
+                notifyError(error, 'Unable to create the model. Review the form and try again.')
+                return { model: null, errors: error?.validationErrors ?? null }
+            } finally {
+                this.creating = false
+            }
+        },
+        async trainModel(modelId, hyperparameters = null) {
+            this.actionState = { ...this.actionState, [modelId]: 'training' }
+            const payload = { model_id: modelId }
+
+            if (hyperparameters && Object.keys(hyperparameters).length > 0) {
+                payload.hyperparameters = hyperparameters
+            }
+
+            try {
+                await apiClient.post('/models/train', payload)
                 notifySuccess({ title: 'Training started', message: 'Model training pipeline initiated.' })
             } catch (error) {
                 notifyError(error, 'Training could not be started. Please retry later.')
@@ -122,9 +160,62 @@ export const useModelStore = defineStore('model', {
 function normaliseModel(model) {
     return {
         id: model.id,
+        datasetId: model.dataset_id ?? null,
         name: model.name,
         status: model.status,
         metrics: model.metrics ?? {},
+        tag: model.tag ?? null,
+        area: model.area ?? null,
+        version: model.version ?? null,
         lastTrainedAt: model.trained_at ?? model.updated_at ?? null,
     }
+}
+
+function extractModel(response) {
+    if (!response) {
+        return null
+    }
+
+    const payload = typeof response?.data === 'undefined' ? response : response.data
+    const candidate = typeof payload?.data === 'undefined' ? payload : payload.data
+
+    if (!candidate) {
+        return null
+    }
+
+    return normaliseModel(candidate)
+}
+
+function sanitizeModelPayload(payload = {}) {
+    const body = {}
+
+    if (payload.name) {
+        body.name = payload.name
+    }
+
+    if (payload.dataset_id || payload.datasetId) {
+        body.dataset_id = payload.dataset_id ?? payload.datasetId
+    }
+
+    if (payload.tag) {
+        body.tag = payload.tag
+    }
+
+    if (payload.area) {
+        body.area = payload.area
+    }
+
+    if (payload.version) {
+        body.version = payload.version
+    }
+
+    if (payload.hyperparameters && Object.keys(payload.hyperparameters).length > 0) {
+        body.hyperparameters = payload.hyperparameters
+    }
+
+    if (payload.metadata && Object.keys(payload.metadata).length > 0) {
+        body.metadata = payload.metadata
+    }
+
+    return body
 }

--- a/frontend/src/stores/model.js
+++ b/frontend/src/stores/model.js
@@ -95,6 +95,7 @@ export const useModelStore = defineStore('model', {
             }
             this.links = { first: null, last: null, prev: null, next: null }
         },
+
         async createModel(payload) {
             this.creating = true
 
@@ -126,6 +127,7 @@ export const useModelStore = defineStore('model', {
                 this.creating = false
             }
         },
+
         async trainModel(modelId, hyperparameters = null) {
             this.actionState = { ...this.actionState, [modelId]: 'training' }
             const payload = { model_id: modelId }
@@ -143,6 +145,7 @@ export const useModelStore = defineStore('model', {
                 this.actionState = { ...this.actionState, [modelId]: 'idle' }
             }
         },
+
         async evaluateModel(modelId) {
             this.actionState = { ...this.actionState, [modelId]: 'evaluating' }
             try {

--- a/frontend/src/views/admin/AdminModelsView.vue
+++ b/frontend/src/views/admin/AdminModelsView.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="space-y-6">
-        <header class="flex flex-wrap items-center justify-between gap-4">
+        <header class="flex flex-wrap items-start justify-between gap-4">
             <div>
                 <h1 class="text-2xl font-semibold text-slate-900">Model governance</h1>
                 <p class="mt-1 max-w-2xl text-sm text-slate-600">
@@ -9,10 +9,27 @@
                 </p>
             </div>
         </header>
-        <ModelsTable />
+        <CreateModelModal v-if="isAdmin" :open="creationOpen" @close="creationOpen = false" @created="handleCreated" />
+        <ModelsTable @request-create="creationOpen = true" />
     </div>
 </template>
 
 <script setup>
+import { ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import CreateModelModal from '../../components/models/CreateModelModal.vue'
 import ModelsTable from '../../components/models/ModelsTable.vue'
+import { useAuthStore } from '../../stores/auth'
+import { useModelStore } from '../../stores/model'
+
+const authStore = useAuthStore()
+const modelStore = useModelStore()
+const { isAdmin } = storeToRefs(authStore)
+
+const creationOpen = ref(false)
+
+function handleCreated() {
+    creationOpen.value = false
+    modelStore.fetchModels({ page: 1 })
+}
 </script>


### PR DESCRIPTION
## Summary
- add an admin-only modal workflow for provisioning models with optional auto-training
- extend the model store to create records, normalise metadata, and hit the correct training endpoint
- expose a creation trigger from the governance table so administrators can start the workflow in-context