### PR TITLE
Enforce header-only API token authentication

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -50,6 +50,10 @@ php artisan test
 | `GET` | `/api/export` | Download aggregated data as CSV (default) or GeoJSON via `format=geojson`. Accepts the same filters as `/api/hexes`. |
 | `POST` | `/api/nlq` | Ask a natural-language question and receive a structured answer describing the translated query. |
 
+### Authentication
+
+Authenticated routes require either an `Authorization: Bearer <token>` header issued by the login endpoint or an `X-API-Key` header when using static API keys. Query string tokens (for example, `?api_token=...`) are not accepted.
+
 ## MCP toolset
 
 | Tool | Purpose |

--- a/backend/app/Http/Middleware/EnsureApiTokenIsValid.php
+++ b/backend/app/Http/Middleware/EnsureApiTokenIsValid.php
@@ -59,10 +59,6 @@ class EnsureApiTokenIsValid
         }
 
         if ($token === null) {
-            $token = $request->query('api_token');
-        }
-
-        if ($token === null) {
             return null;
         }
 

--- a/backend/tests/Feature/AuthApiTest.php
+++ b/backend/tests/Feature/AuthApiTest.php
@@ -114,4 +114,20 @@ class AuthApiTest extends TestCase
             ->assertUnauthorized();
     }
 
+    public function test_query_string_api_token_is_rejected(): void
+    {
+        $user = User::factory()->create([
+            'password' => Hash::make('secret-password'),
+            'role' => Role::Viewer,
+        ]);
+
+        $tokens = $this->postJson('/api/auth/login', [
+            'email' => $user->email,
+            'password' => 'secret-password',
+        ])->json();
+
+        $this->getJson('/api/auth/me?api_token='.$tokens['accessToken'])
+            ->assertUnauthorized();
+    }
+
 }


### PR DESCRIPTION
## Summary
- remove the query-string fallback from the API token middleware so only headers are accepted
- add a regression test asserting that `?api_token` is rejected with a 401
- document the header-based authentication requirements in the backend README