### PR TITLE
Switch auth refresh to secure cookies

### DIFF
--- a/backend/app/Support/SanctumTokenManager.php
+++ b/backend/app/Support/SanctumTokenManager.php
@@ -17,6 +17,8 @@ class SanctumTokenManager
 
     public const REFRESH_ABILITY = 'refresh-api';
 
+    public const REFRESH_COOKIE_NAME = 'refresh_token';
+
     private const TOKEN_PREFIX = 'auth';
 
     /**

--- a/backend/tests/Feature/AuthApiTest.php
+++ b/backend/tests/Feature/AuthApiTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Enums\Role;
 use App\Models\User;
+use App\Support\SanctumTokenManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
@@ -27,10 +28,11 @@ class AuthApiTest extends TestCase
         $response->assertOk();
         $response->assertJsonStructure([
             'accessToken',
-            'refreshToken',
             'user' => ['id', 'name', 'email', 'role'],
             'expiresIn',
         ]);
+        $response->assertJsonMissingPath('refreshToken');
+        $response->assertCookie(SanctumTokenManager::REFRESH_COOKIE_NAME);
 
         $this->assertDatabaseCount('personal_access_tokens', 2);
     }
@@ -42,27 +44,37 @@ class AuthApiTest extends TestCase
             'role' => Role::Analyst,
         ]);
 
-        $login = $this->postJson('/api/auth/login', [
+        $loginResponse = $this->postJson('/api/auth/login', [
             'email' => $user->email,
             'password' => 'secret-password',
-        ])->json();
-
-        $refreshResponse = $this->postJson('/api/auth/refresh', [
-            'refreshToken' => $login['refreshToken'],
         ]);
+
+        $loginResponse->assertCookie(SanctumTokenManager::REFRESH_COOKIE_NAME);
+
+        $login = $loginResponse->json();
+        $refreshToken = $loginResponse->getCookie(SanctumTokenManager::REFRESH_COOKIE_NAME)?->getValue();
+
+        $this->assertIsString($refreshToken);
+        $this->assertNotSame('', $refreshToken);
+
+        $refreshResponse = $this->withCookie(SanctumTokenManager::REFRESH_COOKIE_NAME, $refreshToken)
+            ->postJson('/api/auth/refresh');
 
         $refreshResponse->assertOk();
         $refreshResponse->assertJsonStructure([
             'accessToken',
-            'refreshToken',
             'user' => ['id', 'name', 'email', 'role'],
             'expiresIn',
         ]);
+        $refreshResponse->assertJsonMissingPath('refreshToken');
+        $refreshResponse->assertCookie(SanctumTokenManager::REFRESH_COOKIE_NAME);
 
         $refreshed = $refreshResponse->json();
+        $newRefreshToken = $refreshResponse->getCookie(SanctumTokenManager::REFRESH_COOKIE_NAME)?->getValue();
 
         $this->assertNotSame($login['accessToken'], $refreshed['accessToken']);
-        $this->assertNotSame($login['refreshToken'], $refreshed['refreshToken']);
+        $this->assertIsString($newRefreshToken);
+        $this->assertNotSame($refreshToken, $newRefreshToken);
         $this->assertDatabaseCount('personal_access_tokens', 2);
     }
 
@@ -96,14 +108,24 @@ class AuthApiTest extends TestCase
             'role' => Role::Admin,
         ]);
 
-        $tokens = $this->postJson('/api/auth/login', [
+        $loginResponse = $this->postJson('/api/auth/login', [
             'email' => $user->email,
             'password' => 'secret-password',
-        ])->json();
+        ]);
 
-        $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])
-            ->postJson('/api/auth/logout')
-            ->assertOk();
+        $tokens = $loginResponse->json();
+        $refreshCookie = $loginResponse->getCookie(SanctumTokenManager::REFRESH_COOKIE_NAME);
+        $this->assertNotNull($refreshCookie);
+
+        $logoutResponse = $this->withHeader('Authorization', 'Bearer '.$tokens['accessToken'])
+            ->withCookie($refreshCookie->getName(), $refreshCookie->getValue())
+            ->postJson('/api/auth/logout');
+
+        $logoutResponse->assertOk();
+
+        $clearedCookie = $logoutResponse->getCookie(SanctumTokenManager::REFRESH_COOKIE_NAME);
+        $this->assertNotNull($clearedCookie);
+        $this->assertLessThan(time(), $clearedCookie->getExpiresTime());
 
         $this->assertDatabaseMissing('personal_access_tokens', [
             'token' => $this->hashPersonalAccessToken($tokens['accessToken']),

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -44,8 +44,13 @@ const router = createRouter({
     },
 })
 
-router.beforeEach((to) => {
+router.beforeEach(async (to) => {
     const auth = useAuthStore()
+
+    if (!auth.hasAttemptedSessionRestore) {
+        await auth.restoreSession()
+    }
+
     if (to.meta.requiresAuth && !auth.isAuthenticated) {
         return { name: 'login', query: { redirect: to.fullPath } }
     }

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -50,6 +50,13 @@ apiClient.interceptors.response.use(
 
         // 401 → refresh once
         if (response?.status === 401 && !config.__isRetryRequest) {
+            const url = config.url || ''
+            const isRefreshRequest = typeof url === 'string' && url.includes('/auth/refresh')
+
+            if (isRefreshRequest || !auth?.canRefresh) {
+                return Promise.reject(error)
+            }
+
             if (!refreshPromise) {
                 refreshPromise = auth.refresh().finally(() => { refreshPromise = null })
             }

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -8,7 +8,7 @@ const apiClient = axios.create({
     baseURL: '/api/v1',
     timeout: 15000,
     validateStatus: s => s >= 200 && s < 300,
-    withCredentials: false,
+    withCredentials: true,
 })
 
 const MAX_ATTEMPTS = Number(import.meta.env.VITE_MAX_RETRY_ATTEMPTS || 3)
@@ -84,6 +84,9 @@ apiClient.interceptors.response.use(
 
         if (!config.__notified && !isValidation) {
             config.__notified = true
+            if (!error.requestId && config.metadata?.requestId) {
+                error.requestId = config.metadata.requestId
+            }
             notifyError(error)
         }
 

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -5,23 +5,44 @@ import api from '../services/apiClient'
 export const useAuthStore = defineStore('auth', () => {
     const token = ref(null)
     const user = ref(null)
+    const hasRefreshSession = ref(typeof window !== 'undefined')
+    const hasAttemptedRestore = ref(false)
+    let restorePromise = null
+
+    function clearState() {
+        token.value = null
+        user.value = null
+    }
 
     async function login(credentials) {
         const { email, password } = credentials ?? {}
         const { data } = await api.post('/auth/login', { email, password })
         token.value = data.accessToken
         user.value = data.user
+        hasRefreshSession.value = true
+        hasAttemptedRestore.value = true
         return user.value
     }
 
-    async function refresh() {
+    async function refresh(options = {}) {
+        const { force = false } = options
+
+        if (!force && !hasRefreshSession.value) {
+            hasAttemptedRestore.value = true
+            return null
+        }
+
         try {
             const { data } = await api.post('/auth/refresh')
             token.value = data.accessToken
             user.value = data.user
+            hasRefreshSession.value = true
+            hasAttemptedRestore.value = true
             return token.value
         } catch {
-            await logout()
+            hasRefreshSession.value = false
+            clearState()
+            hasAttemptedRestore.value = true
             return null
         }
     }
@@ -32,13 +53,31 @@ export const useAuthStore = defineStore('auth', () => {
         } catch {
             // ignore logout errors
         }
-        token.value = null
-        user.value = null
+        hasRefreshSession.value = false
+        hasAttemptedRestore.value = true
+        clearState()
+    }
+
+    async function restoreSession() {
+        if (hasAttemptedRestore.value) {
+            return token.value
+        }
+
+        if (!restorePromise) {
+            restorePromise = (hasRefreshSession.value ? refresh() : Promise.resolve(null)).finally(() => {
+                hasAttemptedRestore.value = true
+                restorePromise = null
+            })
+        }
+
+        return restorePromise
     }
 
     const isAuthenticated = computed(() => Boolean(token.value))
     const role = computed(() => user.value?.role ?? '')
     const isAdmin = computed(() => role.value === 'admin')
+    const canRefresh = computed(() => hasRefreshSession.value)
+    const hasAttemptedSessionRestore = computed(() => hasAttemptedRestore.value)
 
     return {
         token,
@@ -49,5 +88,8 @@ export const useAuthStore = defineStore('auth', () => {
         login,
         refresh,
         logout,
+        restoreSession,
+        canRefresh,
+        hasAttemptedSessionRestore,
     }
 })

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -2,55 +2,25 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import api from '../services/apiClient'
 
-const LS_KEY = 'auth_tokens_v1'
-
 export const useAuthStore = defineStore('auth', () => {
     const token = ref(null)
-    const refreshToken = ref(null)
     const user = ref(null)
-
-    // load from localStorage on start
-    ;(() => {
-        try {
-            const raw = localStorage.getItem(LS_KEY)
-            if (raw) {
-                const { accessToken, refreshToken: storedRefreshToken, refresh, profile } = JSON.parse(raw)
-                token.value = accessToken || null
-                refreshToken.value = storedRefreshToken || refresh || null
-                user.value = profile || null
-            }
-        } catch {}
-    })()
-
-    function persist() {
-        localStorage.setItem(LS_KEY, JSON.stringify({
-            accessToken: token.value,
-            refreshToken: refreshToken.value,
-            profile: user.value,
-        }))
-    }
 
     async function login(credentials) {
         const { email, password } = credentials ?? {}
         const { data } = await api.post('/auth/login', { email, password })
         token.value = data.accessToken
-        refreshToken.value = data.refreshToken
         user.value = data.user
-        persist()
         return user.value
     }
 
     async function refresh() {
-        if (!refreshToken.value) return null
         try {
-            const { data } = await api.post('/auth/refresh', { refreshToken: refreshToken.value })
+            const { data } = await api.post('/auth/refresh')
             token.value = data.accessToken
-            // Optionally rotate refresh
-            if (data.refreshToken) refreshToken.value = data.refreshToken
-            persist()
+            user.value = data.user
             return token.value
         } catch {
-            // hard reset on failed refresh
             await logout()
             return null
         }
@@ -58,14 +28,12 @@ export const useAuthStore = defineStore('auth', () => {
 
     async function logout() {
         try {
-            if (token.value) {
-                await api.post('/auth/logout')
-            }
-        } catch { /* ignore */ }
+            await api.post('/auth/logout')
+        } catch {
+            // ignore logout errors
+        }
         token.value = null
-        refreshToken.value = null
         user.value = null
-        localStorage.removeItem(LS_KEY)
     }
 
     const isAuthenticated = computed(() => Boolean(token.value))
@@ -74,7 +42,6 @@ export const useAuthStore = defineStore('auth', () => {
 
     return {
         token,
-        refreshToken,
         user,
         isAuthenticated,
         role,

--- a/frontend/src/stores/plugins/persist.js
+++ b/frontend/src/stores/plugins/persist.js
@@ -1,7 +1,6 @@
 const STORAGE_PREFIX = 'predictive-patterns'
 
 const allowList = {
-    auth: ['token', 'refreshToken'],
     prediction: ['lastFilters'],
     map: ['selectedBaseLayer', 'heatmapOpacity', 'showHeatmap'],
 }

--- a/frontend/tests/authStore.spec.js
+++ b/frontend/tests/authStore.spec.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
 import { useAuthStore } from '../src/stores/auth'
 
 vi.mock('../src/services/apiClient', () => ({
@@ -17,11 +18,11 @@ import apiClient from '../src/services/apiClient'
 
 describe('auth store actions', () => {
     beforeEach(() => {
+        setActivePinia(createPinia())
         vi.clearAllMocks()
     })
 
     it('stores the access token and user after login', async () => {
-        const store = useAuthStore()
         apiClient.post.mockResolvedValue({
             data: {
                 accessToken: 'auth-token',
@@ -32,6 +33,8 @@ describe('auth store actions', () => {
                 },
             },
         })
+
+        const store = useAuthStore()
 
         await store.login({ email: 'admin@example.com', password: 'admin' })
 
@@ -45,10 +48,11 @@ describe('auth store actions', () => {
             name: 'Admin User',
             role: 'admin',
         })
+        expect(store.canRefresh).toBe(true)
+        expect(store.hasAttemptedSessionRestore).toBe(true)
     })
 
     it('refreshes the access token using the cookie-backed endpoint', async () => {
-        const store = useAuthStore()
         apiClient.post.mockResolvedValue({
             data: {
                 accessToken: 'new-token',
@@ -56,43 +60,87 @@ describe('auth store actions', () => {
             },
         })
 
+        const store = useAuthStore()
         const token = await store.refresh()
 
         expect(apiClient.post).toHaveBeenCalledWith('/auth/refresh')
         expect(store.token).toBe('new-token')
         expect(store.user).toEqual({ id: 'user-1', role: 'admin' })
         expect(token).toBe('new-token')
+        expect(store.canRefresh).toBe(true)
     })
 
-    it('clears state when refresh fails and logout is invoked', async () => {
+    it('clears state when refresh fails', async () => {
+        apiClient.post.mockRejectedValue(new Error('expired'))
+
         const store = useAuthStore()
         store.token = 'stale-token'
         store.user = { id: 'user-1' }
 
-        apiClient.post
-            .mockRejectedValueOnce(new Error('expired'))
-            .mockResolvedValueOnce({ data: { message: 'Logged out' } })
-
         const token = await store.refresh()
 
-        expect(apiClient.post).toHaveBeenNthCalledWith(1, '/auth/refresh')
-        expect(apiClient.post).toHaveBeenNthCalledWith(2, '/auth/logout')
+        expect(apiClient.post).toHaveBeenCalledWith('/auth/refresh')
         expect(store.token).toBeNull()
         expect(store.user).toBeNull()
+        expect(store.canRefresh).toBe(false)
         expect(token).toBeNull()
     })
 
+    it('restores a session from the refresh cookie once per load', async () => {
+        apiClient.post.mockResolvedValue({
+            data: {
+                accessToken: 'restored-token',
+                user: { id: 'user-1', role: 'admin' },
+            },
+        })
+
+        const store = useAuthStore()
+
+        const restored = await store.restoreSession()
+
+        expect(apiClient.post).toHaveBeenCalledWith('/auth/refresh')
+        expect(restored).toBe('restored-token')
+        expect(store.token).toBe('restored-token')
+        expect(store.user).toEqual({ id: 'user-1', role: 'admin' })
+        expect(store.hasAttemptedSessionRestore).toBe(true)
+
+        apiClient.post.mockClear()
+
+        await store.restoreSession()
+
+        expect(apiClient.post).not.toHaveBeenCalled()
+    })
+
+    it('skips refresh attempts once the cookie is unavailable', async () => {
+        apiClient.post.mockRejectedValue(new Error('no cookie'))
+
+        const store = useAuthStore()
+
+        await store.restoreSession()
+
+        expect(store.canRefresh).toBe(false)
+        expect(store.hasAttemptedSessionRestore).toBe(true)
+
+        apiClient.post.mockClear()
+
+        await store.refresh()
+
+        expect(apiClient.post).not.toHaveBeenCalled()
+    })
+
     it('logs out and resets state', async () => {
+        apiClient.post.mockResolvedValue({ data: { message: 'Logged out' } })
+
         const store = useAuthStore()
         store.token = 'auth-token'
         store.user = { id: 'user-1' }
-
-        apiClient.post.mockResolvedValue({ data: { message: 'Logged out' } })
 
         await store.logout()
 
         expect(apiClient.post).toHaveBeenCalledWith('/auth/logout')
         expect(store.token).toBeNull()
         expect(store.user).toBeNull()
+        expect(store.canRefresh).toBe(false)
+        expect(store.hasAttemptedSessionRestore).toBe(true)
     })
 })


### PR DESCRIPTION
## Summary
- issue refresh tokens via secure, HttpOnly cookies and read them on refresh while clearing them during logout
- expose the refresh cookie name on the token manager and update feature tests for the cookie-based rotation flow
- stop persisting auth tokens on the frontend, rely on cookie-backed refresh logic, enable Axios credentials, and refresh the associated unit tests
