### PR TITLE
Implement dataset-driven model evaluation

### DIFF
--- a/backend/app/Jobs/EvaluateModelJob.php
+++ b/backend/app/Jobs/EvaluateModelJob.php
@@ -2,7 +2,9 @@
 
 namespace App\Jobs;
 
+use App\Models\Dataset;
 use App\Models\PredictiveModel;
+use App\Services\ModelEvaluationService;
 use App\Services\ModelStatusService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -12,6 +14,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Random\RandomException;
+use RuntimeException;
 use Throwable;
 
 class EvaluateModelJob implements ShouldQueue
@@ -36,44 +39,59 @@ class EvaluateModelJob implements ShouldQueue
      * @throws Throwable
      * @throws RandomException
      */
-    public function handle(ModelStatusService $statusService): void
+    public function handle(ModelStatusService $statusService, ModelEvaluationService $evaluationService): void
     {
         $model = PredictiveModel::query()->findOrFail($this->modelId);
         $metadata = $model->metadata ?? [];
 
         $statusService->markProgress($model->id, 'evaluating', 5.0);
 
-        $entry = [
-            'id' => (string) Str::uuid(),
-            'evaluated_at' => now()->toIso8601String(),
-            'dataset_id' => $this->datasetId,
-            'metrics' => $this->metrics ?? [
-                'precision' => random_int(70, 95) / 100,
-                'recall' => random_int(70, 95) / 100,
-                'f1' => random_int(70, 95) / 100,
-            ],
-        ];
+        $dataset = null;
 
-        if ($this->notes !== null) {
-            $entry['notes'] = $this->notes;
+        if ($this->datasetId !== null) {
+            $dataset = Dataset::query()->findOrFail($this->datasetId);
+        } else {
+            $dataset = $model->dataset;
         }
 
-        $metadata['evaluations'] = array_values(array_filter(
-            array_merge($metadata['evaluations'] ?? [], [$entry]),
-            static fn ($value): bool => is_array($value)
-        ));
-
-        $statusService->markProgress($model->id, 'evaluating', 55.0);
+        $metrics = $this->metrics;
 
         try {
+            if ($metrics === null) {
+                if (! $dataset instanceof Dataset) {
+                    throw new RuntimeException('No dataset available for evaluation.');
+                }
+
+                $metrics = $evaluationService->evaluate($model, $dataset);
+            }
+
+            $entry = [
+                'id' => (string) Str::uuid(),
+                'evaluated_at' => now()->toIso8601String(),
+                'dataset_id' => $dataset?->id,
+                'metrics' => $metrics,
+            ];
+
+            if ($this->notes !== null) {
+                $entry['notes'] = $this->notes;
+            }
+
+            $metadata['evaluations'] = array_values(array_filter(
+                array_merge($metadata['evaluations'] ?? [], [$entry]),
+                static fn ($value): bool => is_array($value)
+            ));
+
+            $statusService->markProgress($model->id, 'evaluating', 55.0);
+
             $model->metadata = $metadata;
             $model->save();
 
             $statusService->markProgress($model->id, 'evaluating', 85.0);
             $statusService->markIdle($model->id);
         } catch (Throwable $exception) {
-            Log::error('Failed to persist evaluation metadata', [
+            Log::error('Failed to evaluate model', [
                 'model_id' => $model->id,
+                'dataset_id' => $dataset?->id,
                 'exception' => $exception->getMessage(),
             ]);
 

--- a/backend/app/Services/ModelEvaluationService.php
+++ b/backend/app/Services/ModelEvaluationService.php
@@ -1,0 +1,372 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Dataset;
+use App\Models\PredictiveModel;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Storage;
+use RuntimeException;
+
+class ModelEvaluationService
+{
+    /**
+     * @param callable|null $progressCallback
+     *
+     * @return array{accuracy: float, precision: float, recall: float, f1: float}
+     */
+    public function evaluate(PredictiveModel $model, Dataset $dataset, ?callable $progressCallback = null): array
+    {
+        $artifactPath = $this->resolveArtifactPath($model);
+        $disk = Storage::disk('local');
+
+        if (! $disk->exists($artifactPath)) {
+            throw new RuntimeException(sprintf('Model artifact "%s" was not found.', $artifactPath));
+        }
+
+        $artifactContents = $disk->get($artifactPath);
+        $artifact = json_decode($artifactContents, true);
+
+        if (! is_array($artifact)) {
+            throw new RuntimeException('Model artifact could not be decoded.');
+        }
+
+        $weights = $this->extractNumericList($artifact['weights'] ?? null, 'weights');
+        $featureMeans = $this->extractNumericList($artifact['feature_means'] ?? null, 'feature_means');
+        $featureStdDevs = $this->extractNumericList($artifact['feature_std_devs'] ?? null, 'feature_std_devs');
+
+        if ($dataset->file_path === null) {
+            throw new RuntimeException('Evaluation dataset is missing a file path.');
+        }
+
+        if (! $disk->exists($dataset->file_path)) {
+            throw new RuntimeException(sprintf('Evaluation dataset "%s" was not found.', $dataset->file_path));
+        }
+
+        if ($progressCallback !== null) {
+            $progressCallback(15.0);
+        }
+
+        $rows = $this->loadCsv($disk->path($dataset->file_path));
+
+        if ($rows === []) {
+            throw new RuntimeException('Evaluation dataset is empty.');
+        }
+
+        $categories = $this->extractStringList($artifact['categories'] ?? null, 'categories');
+
+        if ($progressCallback !== null) {
+            $progressCallback(35.0);
+        }
+
+        $prepared = $this->prepareEntries($rows, $categories);
+
+        if ($progressCallback !== null) {
+            $progressCallback(55.0);
+        }
+
+        $normalized = $this->applyNormalization($prepared['features'], $featureMeans, $featureStdDevs);
+
+        if ($progressCallback !== null) {
+            $progressCallback(70.0);
+        }
+
+        $predictions = $this->predictProbabilities($weights, $normalized);
+        $metrics = $this->calculateMetrics($prepared['labels'], $predictions);
+
+        if ($progressCallback !== null) {
+            $progressCallback(85.0);
+        }
+
+        return $metrics;
+    }
+
+    private function resolveArtifactPath(PredictiveModel $model): string
+    {
+        $metadata = $model->metadata ?? [];
+        $artifactPath = is_array($metadata) ? ($metadata['artifact_path'] ?? null) : null;
+
+        if (! is_string($artifactPath) || $artifactPath === '') {
+            throw new RuntimeException('Model metadata does not contain an artifact path.');
+        }
+
+        return $artifactPath;
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function loadCsv(string $path): array
+    {
+        $handle = fopen($path, 'rb');
+
+        if ($handle === false) {
+            throw new RuntimeException(sprintf('Unable to open evaluation dataset "%s".', $path));
+        }
+
+        try {
+            $rows = [];
+            $header = null;
+
+            while (($data = fgetcsv($handle)) !== false) {
+                if ($header === null) {
+                    $header = array_map(static fn ($value) => is_string($value) ? trim($value) : $value, $data);
+
+                    continue;
+                }
+
+                if ($data === [null] || $data === false) {
+                    continue;
+                }
+
+                $row = [];
+
+                foreach ($header as $index => $column) {
+                    $row[$column] = $data[$index] ?? null;
+                }
+
+                $rows[] = $row;
+            }
+
+            return $rows;
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    /**
+     * @param array<int, array<string, string>> $rows
+     * @param list<string> $categories
+     *
+     * @return array{
+     *     features: list<list<float>>,
+     *     labels: list<int>
+     * }
+     */
+    private function prepareEntries(array $rows, array $categories): array
+    {
+        $requiredColumns = ['timestamp', 'latitude', 'longitude', 'category', 'risk_score', 'label'];
+
+        $features = [];
+        $labels = [];
+
+        foreach ($rows as $row) {
+            foreach ($requiredColumns as $column) {
+                if (! array_key_exists($column, $row)) {
+                    throw new RuntimeException(sprintf('Evaluation dataset is missing required column "%s".', $column));
+                }
+            }
+
+            $timestampString = (string) ($row['timestamp'] ?? '');
+
+            if ($timestampString === '') {
+                continue;
+            }
+
+            $timestamp = CarbonImmutable::parse($timestampString);
+            $hour = $timestamp->hour / 23.0;
+            $dayOfWeek = ($timestamp->dayOfWeekIso - 1) / 6.0;
+
+            $latitude = (float) ($row['latitude'] ?? 0.0);
+            $longitude = (float) ($row['longitude'] ?? 0.0);
+            $riskScore = (float) ($row['risk_score'] ?? 0.0);
+            $label = (int) ($row['label'] ?? 0);
+            $rowCategory = (string) ($row['category'] ?? '');
+
+            $featureRow = [$hour, $dayOfWeek, $latitude, $longitude, $riskScore];
+
+            foreach ($categories as $category) {
+                $featureRow[] = $rowCategory === $category ? 1.0 : 0.0;
+            }
+
+            $features[] = $featureRow;
+            $labels[] = $label;
+        }
+
+        if ($features === []) {
+            throw new RuntimeException('No usable rows were found in the evaluation dataset.');
+        }
+
+        return ['features' => $features, 'labels' => $labels];
+    }
+
+    /**
+     * @param list<list<float>> $features
+     * @param list<float> $means
+     * @param list<float> $stdDevs
+     *
+     * @return list<list<float>>
+     */
+    private function applyNormalization(array $features, array $means, array $stdDevs): array
+    {
+        if ($features === []) {
+            return [];
+        }
+
+        $featureCount = count($features[0]);
+
+        if (count($means) !== $featureCount || count($stdDevs) !== $featureCount) {
+            throw new RuntimeException('Normalization parameters do not match feature vector size.');
+        }
+
+        $normalized = [];
+
+        foreach ($features as $row) {
+            if (count($row) !== $featureCount) {
+                throw new RuntimeException('Feature vector size mismatch during normalization.');
+            }
+
+            $normalized[] = array_map(
+                static fn ($value, $mean, $std) => ($value - $mean) / ($std > 0 ? $std : 1.0),
+                $row,
+                $means,
+                $stdDevs
+            );
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param list<float> $weights
+     * @param list<list<float>> $features
+     *
+     * @return list<float>
+     */
+    private function predictProbabilities(array $weights, array $features): array
+    {
+        $predictions = [];
+
+        foreach ($features as $row) {
+            $input = array_merge([1.0], $row);
+
+            if (count($weights) !== count($input)) {
+                throw new RuntimeException('Model weights do not match feature vector length.');
+            }
+
+            $predictions[] = $this->sigmoid($this->dotProduct($weights, $input));
+        }
+
+        return $predictions;
+    }
+
+    /**
+     * @param list<int> $labels
+     * @param list<float> $predictions
+     *
+     * @return array{accuracy: float, precision: float, recall: float, f1: float}
+     */
+    private function calculateMetrics(array $labels, array $predictions): array
+    {
+        $tp = $tn = $fp = $fn = 0;
+
+        foreach ($predictions as $index => $probability) {
+            $predicted = $probability >= 0.5 ? 1 : 0;
+            $actual = $labels[$index] ?? 0;
+
+            if ($predicted === 1 && $actual === 1) {
+                $tp++;
+            } elseif ($predicted === 0 && $actual === 0) {
+                $tn++;
+            } elseif ($predicted === 1 && $actual === 0) {
+                $fp++;
+            } elseif ($predicted === 0 && $actual === 1) {
+                $fn++;
+            }
+        }
+
+        $total = max(1, $tp + $tn + $fp + $fn);
+        $accuracy = ($tp + $tn) / $total;
+        $precision = $tp + $fp > 0 ? $tp / ($tp + $fp) : 0.0;
+        $recall = $tp + $fn > 0 ? $tp / ($tp + $fn) : 0.0;
+        $f1Denominator = $precision + $recall;
+        $f1 = $f1Denominator > 0 ? (2 * $precision * $recall) / $f1Denominator : 0.0;
+
+        return [
+            'accuracy' => round($accuracy, 4),
+            'precision' => round($precision, 4),
+            'recall' => round($recall, 4),
+            'f1' => round($f1, 4),
+        ];
+    }
+
+    /**
+     * @param list<float>|mixed $values
+     *
+     * @return list<float>
+     */
+    private function extractNumericList(mixed $values, string $key): array
+    {
+        if (! is_array($values)) {
+            throw new RuntimeException(sprintf('Model artifact is missing "%s".', $key));
+        }
+
+        $normalized = [];
+
+        foreach ($values as $value) {
+            if (! is_numeric($value)) {
+                throw new RuntimeException(sprintf('Model artifact contains invalid values for "%s".', $key));
+            }
+
+            $normalized[] = (float) $value;
+        }
+
+        if ($normalized === []) {
+            throw new RuntimeException(sprintf('Model artifact does not contain any values for "%s".', $key));
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param list<string>|mixed $values
+     *
+     * @return list<string>
+     */
+    private function extractStringList(mixed $values, string $key): array
+    {
+        if ($values === null) {
+            return [];
+        }
+
+        if (! is_array($values)) {
+            throw new RuntimeException(sprintf('Model artifact contains invalid values for "%s".', $key));
+        }
+
+        $normalized = [];
+
+        foreach ($values as $value) {
+            if (! is_string($value)) {
+                throw new RuntimeException(sprintf('Model artifact contains invalid values for "%s".', $key));
+            }
+
+            $normalized[] = $value;
+        }
+
+        return $normalized;
+    }
+
+    private function dotProduct(array $a, array $b): float
+    {
+        $sum = 0.0;
+
+        foreach ($a as $index => $value) {
+            $sum += $value * ($b[$index] ?? 0.0);
+        }
+
+        return $sum;
+    }
+
+    private function sigmoid(float $value): float
+    {
+        if ($value < -60) {
+            return 0.0;
+        }
+
+        if ($value > 60) {
+            return 1.0;
+        }
+
+        return 1.0 / (1.0 + exp(-$value));
+    }
+}

--- a/backend/tests/Unit/EvaluateModelJobTest.php
+++ b/backend/tests/Unit/EvaluateModelJobTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Enums\ModelStatus;
+use App\Enums\TrainingStatus;
+use App\Jobs\EvaluateModelJob;
+use App\Models\Dataset;
+use App\Models\PredictiveModel;
+use App\Models\TrainingRun;
+use App\Services\ModelEvaluationService;
+use App\Services\ModelStatusService;
+use App\Services\ModelTrainingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Support\Facades\Storage;
+use RuntimeException;
+use Tests\TestCase;
+
+class EvaluateModelJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_handle_persists_evaluation_metrics(): void
+    {
+        Storage::fake('local');
+        Event::fake();
+        Redis::shouldReceive('setex')->zeroOrMoreTimes()->andReturnTrue();
+        Redis::shouldReceive('publish')->zeroOrMoreTimes()->andReturnTrue();
+        Redis::shouldReceive('get')->zeroOrMoreTimes()->andReturn(null);
+        Redis::shouldReceive('del')->zeroOrMoreTimes()->andReturnTrue();
+
+        $dataset = Dataset::factory()->create([
+            'source_type' => 'file',
+            'file_path' => 'datasets/evaluate.csv',
+            'mime_type' => 'text/csv',
+        ]);
+
+        Storage::disk('local')->put($dataset->file_path, $this->datasetCsv());
+
+        $model = PredictiveModel::factory()->create([
+            'dataset_id' => $dataset->id,
+            'status' => ModelStatus::Draft,
+            'metadata' => [],
+            'metrics' => null,
+            'hyperparameters' => null,
+        ]);
+
+        $run = TrainingRun::query()->create([
+            'model_id' => $model->id,
+            'status' => TrainingStatus::Queued,
+            'queued_at' => now(),
+        ]);
+
+        $trainingService = app(ModelTrainingService::class);
+        $trainingResult = $trainingService->train($run, $model);
+
+        $model->update([
+            'metadata' => array_merge($model->metadata ?? [], ['artifact_path' => $trainingResult['artifact_path']]),
+        ]);
+
+        $job = new EvaluateModelJob($model->id, $dataset->id);
+        $job->handle(
+            app(ModelStatusService::class),
+            app(ModelEvaluationService::class),
+        );
+
+        $model->refresh();
+
+        $this->assertArrayHasKey('evaluations', $model->metadata);
+        $this->assertCount(1, $model->metadata['evaluations']);
+
+        $evaluation = $model->metadata['evaluations'][0];
+
+        $this->assertSame($dataset->id, $evaluation['dataset_id']);
+        $this->assertEquals(['accuracy', 'precision', 'recall', 'f1'], array_keys($evaluation['metrics']));
+        $this->assertEquals(1.0, $evaluation['metrics']['accuracy']);
+    }
+
+    public function test_handle_marks_status_failed_on_evaluation_error(): void
+    {
+        Storage::fake('local');
+        Event::fake();
+        Redis::shouldReceive('setex')->zeroOrMoreTimes()->andReturnTrue();
+        Redis::shouldReceive('publish')->zeroOrMoreTimes()->andReturnTrue();
+        Redis::shouldReceive('get')->zeroOrMoreTimes()->andReturn(null);
+        Redis::shouldReceive('del')->zeroOrMoreTimes()->andReturnTrue();
+
+        $dataset = Dataset::factory()->create([
+            'source_type' => 'file',
+            'file_path' => 'datasets/missing-evaluate.csv',
+        ]);
+
+        $model = PredictiveModel::factory()->create([
+            'dataset_id' => $dataset->id,
+            'status' => ModelStatus::Draft,
+            'metadata' => [],
+        ]);
+
+        Storage::disk('local')->put('models/fake-artifact.json', json_encode([
+            'weights' => array_fill(0, 6, 0.1),
+            'feature_means' => array_fill(0, 5, 0.0),
+            'feature_std_devs' => array_fill(0, 5, 1.0),
+            'categories' => [],
+        ]));
+
+        $model->update([
+            'metadata' => ['artifact_path' => 'models/fake-artifact.json'],
+        ]);
+
+        $job = new EvaluateModelJob($model->id, $dataset->id);
+
+        try {
+            $job->handle(
+                app(ModelStatusService::class),
+                app(ModelEvaluationService::class),
+            );
+            $this->fail('Expected RuntimeException to be thrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString('Evaluation dataset', $exception->getMessage());
+        }
+
+        $model->refresh();
+
+        $this->assertArrayNotHasKey('evaluations', $model->metadata ?? []);
+    }
+
+    private function datasetCsv(): string
+    {
+        return implode("\n", [
+            'timestamp,latitude,longitude,category,risk_score,label',
+            '2024-01-01T00:00:00Z,40.0,-73.9,burglary,0.10,0',
+            '2024-01-02T00:00:00Z,40.0,-73.9,burglary,0.12,0',
+            '2024-01-03T00:00:00Z,40.0,-73.9,burglary,0.14,0',
+            '2024-01-04T00:00:00Z,40.0,-73.9,burglary,0.18,0',
+            '2024-01-05T00:00:00Z,40.0,-73.9,assault,0.72,1',
+            '2024-01-06T00:00:00Z,40.0,-73.9,assault,0.74,1',
+            '2024-01-07T00:00:00Z,40.0,-73.9,assault,0.78,1',
+            '2024-01-08T00:00:00Z,40.0,-73.9,assault,0.82,1',
+            '2024-01-09T00:00:00Z,40.0,-73.9,burglary,0.28,0',
+            '2024-01-10T00:00:00Z,40.0,-73.9,assault,0.88,1',
+            '',
+        ]);
+    }
+}

--- a/backend/tests/Unit/ModelEvaluationServiceTest.php
+++ b/backend/tests/Unit/ModelEvaluationServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Enums\ModelStatus;
+use App\Enums\TrainingStatus;
+use App\Models\Dataset;
+use App\Models\PredictiveModel;
+use App\Models\TrainingRun;
+use App\Services\ModelEvaluationService;
+use App\Services\ModelTrainingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ModelEvaluationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_evaluate_computes_metrics_from_dataset_artifact(): void
+    {
+        Storage::fake('local');
+
+        $dataset = Dataset::factory()->create([
+            'source_type' => 'file',
+            'file_path' => 'datasets/evaluation.csv',
+            'mime_type' => 'text/csv',
+        ]);
+
+        Storage::disk('local')->put($dataset->file_path, $this->datasetCsv());
+
+        $model = PredictiveModel::factory()->create([
+            'dataset_id' => $dataset->id,
+            'status' => ModelStatus::Draft,
+            'metadata' => [],
+            'metrics' => null,
+            'hyperparameters' => null,
+        ]);
+
+        $run = TrainingRun::query()->create([
+            'model_id' => $model->id,
+            'status' => TrainingStatus::Queued,
+            'queued_at' => now(),
+        ]);
+
+        $trainingService = app(ModelTrainingService::class);
+        $trainingResult = $trainingService->train($run, $model);
+
+        $model->update([
+            'metadata' => array_merge($model->metadata ?? [], ['artifact_path' => $trainingResult['artifact_path']]),
+        ]);
+
+        $evaluationService = app(ModelEvaluationService::class);
+        $metrics = $evaluationService->evaluate($model->fresh(), $dataset);
+
+        $this->assertEquals(['accuracy', 'precision', 'recall', 'f1'], array_keys($metrics));
+        $this->assertEquals(1.0, $metrics['accuracy']);
+        $this->assertEquals(1.0, $metrics['precision']);
+        $this->assertEquals(1.0, $metrics['recall']);
+        $this->assertEquals(1.0, $metrics['f1']);
+    }
+
+    private function datasetCsv(): string
+    {
+        return implode("\n", [
+            'timestamp,latitude,longitude,category,risk_score,label',
+            '2024-01-01T00:00:00Z,40.0,-73.9,burglary,0.10,0',
+            '2024-01-02T00:00:00Z,40.0,-73.9,burglary,0.12,0',
+            '2024-01-03T00:00:00Z,40.0,-73.9,burglary,0.14,0',
+            '2024-01-04T00:00:00Z,40.0,-73.9,burglary,0.18,0',
+            '2024-01-05T00:00:00Z,40.0,-73.9,assault,0.72,1',
+            '2024-01-06T00:00:00Z,40.0,-73.9,assault,0.74,1',
+            '2024-01-07T00:00:00Z,40.0,-73.9,assault,0.78,1',
+            '2024-01-08T00:00:00Z,40.0,-73.9,assault,0.82,1',
+            '2024-01-09T00:00:00Z,40.0,-73.9,burglary,0.28,0',
+            '2024-01-10T00:00:00Z,40.0,-73.9,assault,0.88,1',
+            '',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the placeholder metrics in `EvaluateModelJob` with dataset-driven evaluation via a dedicated service
- add `ModelEvaluationService` to load stored artifacts, normalize evaluation data, and compute reproducible metrics
- cover the evaluation workflow with unit tests for both the job and the service

## Testing
- `composer test` *(fails: vendor dependencies require GitHub access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4565aa5d08326b95ce4f07e87e3b8