### PR TITLE
Add lightweight ESLint setup for Vue frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,6 +7,12 @@ npm install
 npm run dev
 ```
 
+### Linting
+
+```bash
+npm run lint
+```
+
 ## Environment variables
 
 | Variable | Description |

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,36 @@
+import js from '@eslint/js';
+import pluginVue from 'eslint-plugin-vue';
+import globals from 'globals';
+
+const vueConfig = pluginVue.configs['flat/vue3-essential'];
+
+export default [
+  {
+    files: ['**/*.{js,vue}'],
+    ignores: ['node_modules/**', 'dist/**']
+  },
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.node
+      }
+    },
+    rules: {
+      ...js.configs.recommended.rules
+    }
+  },
+  {
+    ...vueConfig,
+    files: ['**/*.vue'],
+    languageOptions: {
+      ...vueConfig.languageOptions,
+      globals: {
+        ...globals.browser
+      }
+    }
+  }
+];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --host"
+    "preview": "vite preview --host",
+    "lint": "eslint . --ext .js,.vue"
   },
   "dependencies": {
     "axios": "^1.12.1",
@@ -18,11 +19,15 @@
     "vue-router": "^4.4.5"
   },
   "devDependencies": {
+    "@eslint/js": "^9.17.0",
     "@tailwindcss/vite": "^4.1.13",
     "@types/d": "^1.0.4",
     "@types/leaflet": "^1.9.20",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue/test-utils": "^2.4.3",
+    "eslint": "^9.17.0",
+    "eslint-plugin-vue": "^9.32.0",
+    "globals": "^15.14.0",
     "jsdom": "^24.0.0",
     "rollup": "4.22.4",
     "vite": "^7.1.5",


### PR DESCRIPTION
## Summary
- add an eslint-based lint script that checks Vue SFCs and JavaScript modules
- introduce a minimal flat ESLint configuration tuned for Vue 3 and browser globals
- document how to run the linter alongside existing frontend development commands

## Testing
- npm run lint *(fails: missing @eslint/js due to restricted npm registry access in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d45862a304832690d1dcdca50df612