### PR TITLE
Normalize dataset headers during CSV ingestion

### DIFF
--- a/backend/app/Services/ModelTrainingService.php
+++ b/backend/app/Services/ModelTrainingService.php
@@ -151,7 +151,7 @@ class ModelTrainingService
 
             while (($data = fgetcsv($handle)) !== false) {
                 if ($header === null) {
-                    $header = array_map(static fn ($value) => is_string($value) ? trim($value) : $value, $data);
+                    $header = $this->normalizeHeaderRow($data);
 
                     continue;
                 }
@@ -163,6 +163,10 @@ class ModelTrainingService
                 $row = [];
 
                 foreach ($header as $index => $column) {
+                    if (! is_string($column) || $column === '') {
+                        continue;
+                    }
+
                     $row[$column] = $data[$index] ?? null;
                 }
 
@@ -256,6 +260,64 @@ class ModelTrainingService
             'feature_names' => $featureNames,
             'categories' => $categoryList,
         ];
+    }
+
+    /**
+     * @param array<int, mixed> $columns
+     *
+     * @return array<int, string>
+     */
+    private function normalizeHeaderRow(array $columns): array
+    {
+        $normalized = [];
+        $used = [];
+
+        foreach ($columns as $value) {
+            if (! is_string($value)) {
+                $normalized[] = '';
+
+                continue;
+            }
+
+            $column = $this->normalizeColumnName($value);
+
+            if ($column === '') {
+                $column = trim($value);
+            }
+
+            $base = $column;
+            $suffix = 1;
+
+            while ($column !== '' && in_array($column, $used, true)) {
+                $suffix++;
+                $column = sprintf('%s_%d', $base, $suffix);
+            }
+
+            if ($column !== '') {
+                $used[] = $column;
+            }
+
+            $normalized[] = $column;
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeColumnName(string $column): string
+    {
+        $column = preg_replace('/^\xEF\xBB\xBF/u', '', $column) ?? $column; // Remove UTF-8 BOM.
+        $column = trim($column);
+
+        if ($column === '') {
+            return '';
+        }
+
+        $column = mb_strtolower($column, 'UTF-8');
+        $column = str_replace(['-', '/'], ' ', $column);
+        $column = preg_replace('/[^a-z0-9]+/u', '_', $column) ?? $column;
+        $column = preg_replace('/_+/', '_', $column) ?? $column;
+
+        return trim($column, '_');
     }
 
     /**


### PR DESCRIPTION
## Summary
- normalise CSV headers when loading datasets for training and evaluation to handle BOMs, spacing, and casing differences
- add unit tests that cover datasets with varied header formatting for both training and evaluation services