### PR TITLE
Invalidate heatmap caches after crime ingestion

### DIFF
--- a/backend/app/Services/H3AggregationService.php
+++ b/backend/app/Services/H3AggregationService.php
@@ -186,15 +186,34 @@ class H3AggregationService
      */
     private function getCacheVersion(): int
     {
-        $version = Cache::get(self::CACHE_VERSION_KEY);
+        $this->initialiseCacheVersion();
 
-        if ($version === null) {
-            Cache::forever(self::CACHE_VERSION_KEY, 1);
+        return (int) Cache::get(self::CACHE_VERSION_KEY, 1);
+    }
 
-            return 1;
+    /**
+     * Increment the cache version so downstream caches pick up fresh aggregates.
+     */
+    public function bumpCacheVersion(): int
+    {
+        $this->initialiseCacheVersion();
+
+        $version = Cache::increment(self::CACHE_VERSION_KEY);
+
+        if (!is_int($version)) {
+            $version = (int) Cache::get(self::CACHE_VERSION_KEY, 1) + 1;
+            Cache::forever(self::CACHE_VERSION_KEY, $version);
         }
 
-        return (int) $version;
+        return $version;
+    }
+
+    /**
+     * Ensure the cache version key exists before it is read or mutated.
+     */
+    private function initialiseCacheVersion(): void
+    {
+        Cache::add(self::CACHE_VERSION_KEY, 1);
     }
 
     /**

--- a/backend/app/Services/H3AggregationService.php
+++ b/backend/app/Services/H3AggregationService.php
@@ -213,7 +213,7 @@ class H3AggregationService
      */
     private function initialiseCacheVersion(): void
     {
-        Cache::add(self::CACHE_VERSION_KEY, 1);
+        Cache::rememberForever(self::CACHE_VERSION_KEY, static fn () => 1);
     }
 
     /**

--- a/backend/app/Services/PoliceCrimeIngestionService.php
+++ b/backend/app/Services/PoliceCrimeIngestionService.php
@@ -31,7 +31,10 @@ class PoliceCrimeIngestionService
     private readonly int $progressInterval;
     private readonly string $tempDirectory;
 
-    public function __construct(private readonly H3IndexService $h3IndexService)
+    public function __construct(
+        private readonly H3IndexService $h3IndexService,
+        private readonly H3AggregationService $h3AggregationService,
+    )
     {
         $config = (array)config('crime.ingestion');
         $this->chunkSize = max(1, (int)($config['chunk_size'] ?? 500));
@@ -617,6 +620,7 @@ class PoliceCrimeIngestionService
 
         if (!$dryRun && $insertable > 0) {
             Crime::query()->insert($buffer);
+            $this->h3AggregationService->bumpCacheVersion();
         }
 
         $buffer = [];

--- a/backend/tests/Feature/DatasetApiTest.php
+++ b/backend/tests/Feature/DatasetApiTest.php
@@ -7,8 +7,10 @@ use App\Enums\DatasetStatus;
 use App\Enums\Role;
 use App\Models\CrimeIngestionRun;
 use App\Models\Dataset;
+use App\Services\H3AggregationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
@@ -19,6 +21,7 @@ class DatasetApiTest extends TestCase
     public function test_dataset_ingest_accepts_file_upload(): void
     {
         Storage::fake('local');
+        Cache::flush();
 
         $csv = <<<CSV
 Type,Date,Part of a policing operation,Policing operation,Latitude,Longitude,Gender,Age range,Self-defined ethnicity,Officer-defined ethnicity,Legislation,Object of search,Outcome,Outcome linked to object of search,Removal of more than just outer clothing
@@ -80,6 +83,11 @@ CSV;
             'dataset_id' => $data['id'],
             'name' => 'Person search',
         ]);
+
+        $this->assertSame(
+            2,
+            Cache::get(H3AggregationService::CACHE_VERSION_KEY)
+        );
     }
 
     public function test_dataset_ingest_accepts_excel_mime_for_csv_uploads(): void


### PR DESCRIPTION
## Summary
- add a cache version bump helper to `H3AggregationService` so aggregate cache keys refresh predictably
- bump the aggregation cache version after police crime ingestion inserts and after dataset-derived feature refreshes
- extend dataset ingestion, hex aggregation, and heatmap tile tests to cover cache invalidation behaviour