### PR TITLE
Enable training services to use schema mapping

### DIFF
--- a/backend/app/Http/Controllers/Api/v1/DatasetController.php
+++ b/backend/app/Http/Controllers/Api/v1/DatasetController.php
@@ -374,7 +374,7 @@ class DatasetController extends Controller
             return [];
         }
 
-        $allowed = ['timestamp', 'latitude', 'longitude', 'category', 'risk'];
+        $allowed = ['timestamp', 'latitude', 'longitude', 'category', 'risk', 'label'];
         $normalised = [];
 
         foreach ($allowed as $key) {

--- a/backend/tests/Unit/ModelEvaluationServiceTest.php
+++ b/backend/tests/Unit/ModelEvaluationServiceTest.php
@@ -110,6 +110,72 @@ class ModelEvaluationServiceTest extends TestCase
         $this->assertEquals(1.0, $metrics['f1']);
     }
 
+    public function test_evaluate_respects_schema_mapping_definitions(): void
+    {
+        Storage::fake('local');
+
+        $trainingDataset = Dataset::factory()->create([
+            'source_type' => 'file',
+            'file_path' => 'datasets/mapped-training.csv',
+            'mime_type' => 'text/csv',
+            'schema_mapping' => [
+                'timestamp' => 'event_time',
+                'latitude' => 'lat_deg',
+                'longitude' => 'lon_deg',
+                'category' => 'incident_type',
+                'risk' => 'risk_index',
+                'label' => 'label_flag',
+            ],
+        ]);
+
+        Storage::disk('local')->put($trainingDataset->file_path, $this->datasetCsvWithSchemaMapping());
+
+        $model = PredictiveModel::factory()->create([
+            'dataset_id' => $trainingDataset->id,
+            'status' => ModelStatus::Draft,
+            'metadata' => [],
+            'metrics' => null,
+            'hyperparameters' => null,
+        ]);
+
+        $run = TrainingRun::query()->create([
+            'model_id' => $model->id,
+            'status' => TrainingStatus::Queued,
+            'queued_at' => now(),
+        ]);
+
+        $trainingService = app(ModelTrainingService::class);
+        $trainingResult = $trainingService->train($run, $model);
+
+        $model->update([
+            'metadata' => array_merge($model->metadata ?? [], ['artifact_path' => $trainingResult['artifact_path']]),
+        ]);
+
+        $evaluationDataset = Dataset::factory()->create([
+            'source_type' => 'file',
+            'file_path' => 'datasets/mapped-evaluation.csv',
+            'mime_type' => 'text/csv',
+            'schema_mapping' => [
+                'timestamp' => 'event_time',
+                'latitude' => 'lat_deg',
+                'longitude' => 'lon_deg',
+                'category' => 'incident_type',
+                'risk' => 'risk_index',
+                'label' => 'label_flag',
+            ],
+        ]);
+
+        Storage::disk('local')->put($evaluationDataset->file_path, $this->datasetCsvWithSchemaMapping());
+
+        $evaluationService = app(ModelEvaluationService::class);
+        $metrics = $evaluationService->evaluate($model->fresh(), $evaluationDataset);
+
+        $this->assertEquals(1.0, $metrics['accuracy']);
+        $this->assertEquals(1.0, $metrics['precision']);
+        $this->assertEquals(1.0, $metrics['recall']);
+        $this->assertEquals(1.0, $metrics['f1']);
+    }
+
     private function datasetCsv(): string
     {
         return implode("\n", [
@@ -132,6 +198,24 @@ class ModelEvaluationServiceTest extends TestCase
     {
         return implode("\n", [
             "\u{FEFF}Timestamp, Latitude ,Longitude , Category ,Risk Score ,Label",
+            '2024-01-01T00:00:00Z,40.0,-73.9,burglary,0.10,0',
+            '2024-01-02T00:00:00Z,40.0,-73.9,burglary,0.12,0',
+            '2024-01-03T00:00:00Z,40.0,-73.9,burglary,0.14,0',
+            '2024-01-04T00:00:00Z,40.0,-73.9,burglary,0.18,0',
+            '2024-01-05T00:00:00Z,40.0,-73.9,assault,0.72,1',
+            '2024-01-06T00:00:00Z,40.0,-73.9,assault,0.74,1',
+            '2024-01-07T00:00:00Z,40.0,-73.9,assault,0.78,1',
+            '2024-01-08T00:00:00Z,40.0,-73.9,assault,0.82,1',
+            '2024-01-09T00:00:00Z,40.0,-73.9,burglary,0.28,0',
+            '2024-01-10T00:00:00Z,40.0,-73.9,assault,0.88,1',
+            '',
+        ]);
+    }
+
+    private function datasetCsvWithSchemaMapping(): string
+    {
+        return implode("\n", [
+            'event_time,lat_deg,lon_deg,incident_type,risk_index,label_flag',
             '2024-01-01T00:00:00Z,40.0,-73.9,burglary,0.10,0',
             '2024-01-02T00:00:00Z,40.0,-73.9,burglary,0.12,0',
             '2024-01-03T00:00:00Z,40.0,-73.9,burglary,0.14,0',


### PR DESCRIPTION
## Summary
- allow dataset ingest schema mappings to include label columns for training workflows
- resolve dataset column names via schema mappings inside the model training and evaluation services
- cover schema-mapped datasets with new unit tests for training and evaluation services