### PR TITLE
Refine modal styling and reorganise predict view

### DIFF
--- a/frontend/src/components/common/BaseModal.vue
+++ b/frontend/src/components/common/BaseModal.vue
@@ -8,7 +8,12 @@
             role="dialog"
             aria-modal="true"
         >
-            <div class="w-full max-w-3xl overflow-hidden rounded-2xl bg-white shadow-xl">
+            <div
+                :class="[
+                    'w-full overflow-hidden rounded-2xl bg-white shadow-xl',
+                    dialogClass,
+                ]"
+            >
                 <header
                     class="flex items-start justify-between gap-4 border-b border-stone-200 px-6 py-6"
                 >
@@ -28,17 +33,24 @@
                 </header>
 
                 <nav
+                    v-if="hasSteps"
                     aria-label="Wizard steps"
                     class="border-b border-stone-200 bg-stone-50"
                 >
                     <slot name="steps" />
                 </nav>
 
-                <section class="max-h-[60vh] overflow-y-auto px-6 py-6 text-sm text-stone-700">
+                <section
+                    :class="[
+                        'overflow-y-auto px-6 py-6 text-sm text-stone-700',
+                        bodyClass,
+                    ]"
+                >
                     <slot />
                 </section>
 
                 <footer
+                    v-if="hasFooter"
                     class="flex items-center justify-between gap-3 border-t border-stone-200 px-6 py-4"
                 >
                     <slot name="footer" />
@@ -49,10 +61,31 @@
 </template>
 
 <script setup>
+import { computed, useSlots } from 'vue'
+
 const props = defineProps({
     open: {
         type: Boolean,
         default: false,
     },
+    dialogClass: {
+        type: String,
+        default: 'max-w-3xl',
+    },
+    bodyClass: {
+        type: String,
+        default: 'max-h-[60vh]',
+    },
 })
+
+const emit = defineEmits(['close'])
+
+const slots = useSlots()
+
+const hasSteps = computed(() => Boolean(slots.steps))
+const hasFooter = computed(() => Boolean(slots.footer))
+
+function close() {
+    emit('close')
+}
 </script>

--- a/frontend/src/components/models/CreateModelModal.vue
+++ b/frontend/src/components/models/CreateModelModal.vue
@@ -1,248 +1,237 @@
 <template>
-    <Teleport to="body" v-if="open">
-        <div
-            class="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/60 px-4 py-8"
-            role="dialog"
-            aria-modal="true"
+    <BaseModal
+        :open="open"
+        @close="close"
+    >
+        <template #header>
+            <h2 class="text-lg font-semibold text-stone-900">Create a new model</h2>
+            <p class="mt-1 text-sm text-stone-600">
+                Provide the model details and optionally queue an initial training run right away.
+            </p>
+        </template>
+
+        <template #steps>
+            <ol class="flex divide-x divide-stone-200 text-sm">
+                <li
+                    v-for="stepLabel in steps"
+                    :key="stepLabel.id"
+                    :aria-current="step === stepLabel.id ? 'step' : undefined"
+                    class="flex-1 px-4 py-3"
+                >
+                    <span
+                        :class="[
+                            'font-medium',
+                            step === stepLabel.id ? 'text-blue-600' : 'text-stone-500',
+                        ]"
+                    >
+                        {{ stepLabel.label }}
+                    </span>
+                </li>
+            </ol>
+        </template>
+
+        <form
+            id="create-model-form"
+            class="space-y-6"
+            @submit.prevent="handleSubmit"
         >
-            <div class="w-full max-w-3xl overflow-hidden rounded-2xl bg-white shadow-xl">
-                <header class="flex items-start justify-between gap-4 border-b border-stone-200 px-6 py-4">
+            <div v-if="step === 1" class="space-y-6">
+                <div class="space-y-5 rounded-xl border border-stone-200 bg-stone-50/60 p-5">
                     <div>
-                        <h2 class="text-lg font-semibold text-stone-900">Create a new model</h2>
+                        <h3 class="text-sm font-semibold uppercase tracking-wide text-stone-600">Model overview</h3>
                         <p class="mt-1 text-sm text-stone-600">
-                            Provide the model details and optionally queue an initial training run right away.
+                            Define the core identifiers for the model and connect it to an approved dataset.
                         </p>
                     </div>
-                    <button
-                        type="button"
-                        class="rounded-full p-2 text-stone-500 transition hover:bg-stone-100 hover:text-stone-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-                        @click="close"
-                    >
-                        <span class="sr-only">Close wizard</span>
-                        <svg aria-hidden="true" class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path d="M6 18L18 6M6 6l12 12" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        </svg>
-                    </button>
-                </header>
-                <nav aria-label="Wizard steps" class="border-b border-stone-200 bg-stone-50">
-                    <ol class="flex divide-x divide-stone-200 text-sm">
-                        <li
-                            v-for="stepLabel in steps"
-                            :key="stepLabel.id"
-                            :aria-current="step === stepLabel.id ? 'step' : undefined"
-                            class="flex-1 px-4 py-3"
-                        >
-                            <span
-                                :class="[
-                                    'font-medium',
-                                    step === stepLabel.id ? 'text-blue-600' : 'text-stone-500',
-                                ]"
-                            >
-                                {{ stepLabel.label }}
-                            </span>
-                        </li>
-                    </ol>
-                </nav>
-                <form @submit.prevent="handleSubmit" class="flex flex-col">
-                    <section class="max-h-[60vh] overflow-y-auto px-6 py-6 text-sm text-stone-700">
-                        <div v-if="step === 1" class="space-y-6">
-                            <div class="space-y-5 rounded-xl border border-stone-200 bg-stone-50/60 p-5">
-                                <div>
-                                    <h3 class="text-sm font-semibold uppercase tracking-wide text-stone-600">Model overview</h3>
-                                    <p class="mt-1 text-sm text-stone-600">
-                                        Define the core identifiers for the model and connect it to an approved dataset.
-                                    </p>
-                                </div>
-                                <div class="space-y-5 text-stone-700">
-                                    <div>
-                                        <label for="model-name" class="block text-sm font-medium text-stone-700">Model name</label>
-                                        <input
-                                            id="model-name"
-                                            v-model="form.name"
-                                            type="text"
-                                            name="name"
-                                            class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                            placeholder="e.g. Spatial Graph Attention"
-                                            autocomplete="off"
-                                        />
-                                        <p v-if="errors.name" class="mt-1 text-sm text-rose-600">{{ errors.name }}</p>
-                                    </div>
-                                    <div>
-                                        <div class="flex flex-wrap items-center justify-between gap-3">
-                                            <label for="dataset-id" class="block text-sm font-medium text-stone-700">Dataset</label>
-                                            <button
-                                                type="button"
-                                                class="text-xs font-medium text-blue-600 transition hover:text-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-                                                :disabled="datasetLoading"
-                                                @click="refreshDatasets"
-                                            >
-                                                {{ datasetLoading ? 'Refreshing…' : 'Refresh list' }}
-                                            </button>
-                                        </div>
-                                        <input
-                                            :list="datasetListId"
-                                            id="dataset-id"
-                                            v-model="form.datasetId"
-                                            type="text"
-                                            name="dataset"
-                                            class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                            placeholder="Search or enter a dataset identifier"
-                                            autocomplete="off"
-                                            @focus="ensureDatasetsLoaded"
-                                        />
-                                        <datalist :id="datasetListId">
-                                            <option
-                                                v-for="option in datasetOptions"
-                                                :key="option.id"
-                                                :value="option.id"
-                                                :label="datasetLabel(option)"
-                                            >
-                                                {{ datasetLabel(option) }}
-                                            </option>
-                                        </datalist>
-                                        <p class="mt-1 text-xs text-stone-500">
-                                            Start typing to filter existing datasets or leave blank to assign a dataset later.
-                                        </p>
-                                        <p v-if="datasetError" class="mt-1 text-sm text-rose-600">{{ datasetError }}</p>
-                                        <p v-else-if="!datasetLoading && !datasetOptions.length" class="mt-1 text-sm text-stone-500">
-                                            No ready datasets are available right now. You can still provide a dataset identifier manually.
-                                        </p>
-                                        <p v-if="errors.datasetId" class="mt-1 text-sm text-rose-600">{{ errors.datasetId }}</p>
-                                    </div>
-                                    <div class="grid gap-4 sm:grid-cols-2">
-                                        <div>
-                                            <label for="model-tag" class="block text-sm font-medium text-stone-700">Tag</label>
-                                            <input
-                                                id="model-tag"
-                                                v-model="form.tag"
-                                                type="text"
-                                                name="tag"
-                                                class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                                placeholder="Optional tag (e.g. baseline)"
-                                                autocomplete="off"
-                                            />
-                                            <p v-if="errors.tag" class="mt-1 text-sm text-rose-600">{{ errors.tag }}</p>
-                                        </div>
-                                        <div>
-                                            <label for="model-area" class="block text-sm font-medium text-stone-700">Area</label>
-                                            <input
-                                                id="model-area"
-                                                v-model="form.area"
-                                                type="text"
-                                                name="area"
-                                                class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                                placeholder="Optional geography or scope"
-                                                autocomplete="off"
-                                            />
-                                            <p v-if="errors.area" class="mt-1 text-sm text-rose-600">{{ errors.area }}</p>
-                                        </div>
-                                        <div>
-                                            <label for="model-version" class="block text-sm font-medium text-stone-700">Version</label>
-                                            <input
-                                                id="model-version"
-                                                v-model="form.version"
-                                                type="text"
-                                                name="version"
-                                                class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                                placeholder="Defaults to 1.0.0"
-                                                autocomplete="off"
-                                            />
-                                            <p v-if="errors.version" class="mt-1 text-sm text-rose-600">{{ errors.version }}</p>
-                                        </div>
-                                    </div>
-                                </div>
+                    <div class="space-y-5 text-stone-700">
+                        <div>
+                            <label for="model-name" class="block text-sm font-medium text-stone-700">Model name</label>
+                            <input
+                                id="model-name"
+                                v-model="form.name"
+                                type="text"
+                                name="name"
+                                class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                placeholder="e.g. Spatial Graph Attention"
+                                autocomplete="off"
+                            />
+                            <p v-if="errors.name" class="mt-1 text-sm text-rose-600">{{ errors.name }}</p>
+                        </div>
+                        <div>
+                            <div class="flex flex-wrap items-center justify-between gap-3">
+                                <label for="dataset-id" class="block text-sm font-medium text-stone-700">Dataset</label>
+                                <button
+                                    type="button"
+                                    class="text-xs font-medium text-blue-600 transition hover:text-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                                    :disabled="datasetLoading"
+                                    @click="refreshDatasets"
+                                >
+                                    {{ datasetLoading ? 'Refreshing…' : 'Refresh list' }}
+                                </button>
+                            </div>
+                            <input
+                                :list="datasetListId"
+                                id="dataset-id"
+                                v-model="form.datasetId"
+                                type="text"
+                                name="dataset"
+                                class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                placeholder="Search or enter a dataset identifier"
+                                autocomplete="off"
+                                @focus="ensureDatasetsLoaded"
+                            />
+                            <datalist :id="datasetListId">
+                                <option
+                                    v-for="option in datasetOptions"
+                                    :key="option.id"
+                                    :value="option.id"
+                                    :label="datasetLabel(option)"
+                                >
+                                    {{ datasetLabel(option) }}
+                                </option>
+                            </datalist>
+                            <p class="mt-1 text-xs text-stone-500">
+                                Start typing to filter existing datasets or leave blank to assign a dataset later.
+                            </p>
+                            <p v-if="datasetError" class="mt-1 text-sm text-rose-600">{{ datasetError }}</p>
+                            <p v-else-if="!datasetLoading && !datasetOptions.length" class="mt-1 text-sm text-stone-500">
+                                No ready datasets are available right now. You can still provide a dataset identifier manually.
+                            </p>
+                            <p v-if="errors.datasetId" class="mt-1 text-sm text-rose-600">{{ errors.datasetId }}</p>
+                        </div>
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <div>
+                                <label for="model-tag" class="block text-sm font-medium text-stone-700">Tag</label>
+                                <input
+                                    id="model-tag"
+                                    v-model="form.tag"
+                                    type="text"
+                                    name="tag"
+                                    class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                    placeholder="Optional tag (e.g. baseline)"
+                                    autocomplete="off"
+                                />
+                                <p v-if="errors.tag" class="mt-1 text-sm text-rose-600">{{ errors.tag }}</p>
+                            </div>
+                            <div>
+                                <label for="model-area" class="block text-sm font-medium text-stone-700">Area</label>
+                                <input
+                                    id="model-area"
+                                    v-model="form.area"
+                                    type="text"
+                                    name="area"
+                                    class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                    placeholder="Optional geography or scope"
+                                    autocomplete="off"
+                                />
+                                <p v-if="errors.area" class="mt-1 text-sm text-rose-600">{{ errors.area }}</p>
+                            </div>
+                            <div>
+                                <label for="model-version" class="block text-sm font-medium text-stone-700">Version</label>
+                                <input
+                                    id="model-version"
+                                    v-model="form.version"
+                                    type="text"
+                                    name="version"
+                                    class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                    placeholder="Defaults to 1.0.0"
+                                    autocomplete="off"
+                                />
+                                <p v-if="errors.version" class="mt-1 text-sm text-rose-600">{{ errors.version }}</p>
                             </div>
                         </div>
-                        <div v-else-if="step === 2" class="space-y-6">
-                            <div class="space-y-5 rounded-xl border border-stone-200 p-5">
-                                <div>
-                                    <h3 class="text-sm font-semibold uppercase tracking-wide text-stone-600">Training & metadata</h3>
-                                    <p class="mt-1 text-sm text-stone-600">
-                                        Provide optional configuration for the initial training job and add descriptive metadata.
-                                    </p>
-                                </div>
-                                <div class="grid gap-4 md:grid-cols-2">
-                                    <div>
-                                        <label for="model-hyperparameters" class="block text-sm font-medium text-stone-700">
-                                            Hyperparameters (JSON)
-                                        </label>
-                                        <textarea
-                                            id="model-hyperparameters"
-                                            v-model="form.hyperparameters"
-                                            name="hyperparameters"
-                                            rows="4"
-                                            class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                            placeholder='{ "learning_rate": 0.01 }'
-                                        ></textarea>
-                                        <p v-if="errors.hyperparameters" class="mt-1 text-sm text-rose-600">{{ errors.hyperparameters }}</p>
-                                    </div>
-                                    <div>
-                                        <label for="model-metadata" class="block text-sm font-medium text-stone-700">Metadata (JSON)</label>
-                                        <textarea
-                                            id="model-metadata"
-                                            v-model="form.metadata"
-                                            name="metadata"
-                                            rows="4"
-                                            class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                            placeholder='{ "notes": "First experiment" }'
-                                        ></textarea>
-                                        <p v-if="errors.metadata" class="mt-1 text-sm text-rose-600">{{ errors.metadata }}</p>
-                                    </div>
-                                </div>
-                                <div class="flex items-center gap-3 rounded-lg bg-stone-50 px-4 py-3">
-                                    <input
-                                        id="auto-train"
-                                        v-model="form.autoTrain"
-                                        type="checkbox"
-                                        class="h-4 w-4 rounded border-stone-300 text-blue-600 focus:ring-blue-500"
-                                    />
-                                    <label for="auto-train" class="text-sm text-stone-700">Queue an initial training run after creating the model</label>
-                                </div>
-                            </div>
-                        </div>
-                    </section>
-                    <footer class="flex items-center justify-between gap-3 border-t border-stone-200 px-6 py-4">
-                        <button
-                            type="button"
-                            class="rounded-md border border-stone-300 px-4 py-2 text-sm font-semibold text-stone-700 shadow-sm transition hover:border-stone-400 hover:text-stone-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
-                            @click="goBack"
-                            :disabled="step === 1 || submitting"
-                        >
-                            Back
-                        </button>
-                        <div class="flex items-center gap-3">
-                            <button
-                                v-if="step < steps.length"
-                                type="button"
-                                class="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:bg-stone-400"
-                                :disabled="!canContinue || submitting"
-                                @click="goNext"
-                            >
-                                Continue
-                            </button>
-                            <button
-                                v-else
-                                type="submit"
-                                class="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:bg-stone-400"
-                                :disabled="submitting"
-                            >
-                                <span v-if="submitting">Creating…</span>
-                                <span v-else>Create model</span>
-                            </button>
-                            <button
-                                type="button"
-                                class="rounded-md border border-stone-300 px-4 py-2 text-sm font-semibold text-stone-700 shadow-sm transition hover:border-stone-400 hover:text-stone-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-                                @click="close"
-                                :disabled="submitting"
-                            >
-                                Cancel
-                            </button>
-                        </div>
-                    </footer>
-                </form>
+                    </div>
+                </div>
             </div>
-        </div>
-    </Teleport>
+            <div v-else-if="step === 2" class="space-y-6">
+                <div class="space-y-5 rounded-xl border border-stone-200 p-5">
+                    <div>
+                        <h3 class="text-sm font-semibold uppercase tracking-wide text-stone-600">Training & metadata</h3>
+                        <p class="mt-1 text-sm text-stone-600">
+                            Provide optional configuration for the initial training job and add descriptive metadata.
+                        </p>
+                    </div>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label for="model-hyperparameters" class="block text-sm font-medium text-stone-700">
+                                Hyperparameters (JSON)
+                            </label>
+                            <textarea
+                                id="model-hyperparameters"
+                                v-model="form.hyperparameters"
+                                name="hyperparameters"
+                                rows="4"
+                                class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                placeholder='{ "learning_rate": 0.01 }'
+                            ></textarea>
+                            <p v-if="errors.hyperparameters" class="mt-1 text-sm text-rose-600">{{ errors.hyperparameters }}</p>
+                        </div>
+                        <div>
+                            <label for="model-metadata" class="block text-sm font-medium text-stone-700">Metadata (JSON)</label>
+                            <textarea
+                                id="model-metadata"
+                                v-model="form.metadata"
+                                name="metadata"
+                                rows="4"
+                                class="mt-1 block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                placeholder='{ "notes": "First experiment" }'
+                            ></textarea>
+                            <p v-if="errors.metadata" class="mt-1 text-sm text-rose-600">{{ errors.metadata }}</p>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-3 rounded-lg bg-stone-50 px-4 py-3">
+                        <input
+                            id="auto-train"
+                            v-model="form.autoTrain"
+                            type="checkbox"
+                            class="h-4 w-4 rounded border-stone-300 text-blue-600 focus:ring-blue-500"
+                        />
+                        <label for="auto-train" class="text-sm text-stone-700">Queue an initial training run after creating the model</label>
+                    </div>
+                </div>
+            </div>
+        </form>
+
+        <template #footer>
+            <button
+                type="button"
+                class="rounded-md border border-stone-300 px-4 py-2 text-sm font-semibold text-stone-700 shadow-sm transition hover:border-stone-400 hover:text-stone-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+                @click="goBack"
+                :disabled="step === 1 || submitting"
+            >
+                Back
+            </button>
+            <div class="flex items-center gap-3">
+                <button
+                    v-if="step < steps.length"
+                    type="button"
+                    class="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:bg-stone-400"
+                    :disabled="!canContinue || submitting"
+                    @click="goNext"
+                >
+                    Continue
+                </button>
+                <button
+                    v-else
+                    type="submit"
+                    form="create-model-form"
+                    class="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:bg-stone-400"
+                    :disabled="submitting"
+                >
+                    <span v-if="submitting">Creating…</span>
+                    <span v-else>Create model</span>
+                </button>
+                <button
+                    type="button"
+                    class="rounded-md border border-stone-300 px-4 py-2 text-sm font-semibold text-stone-700 shadow-sm transition hover:border-stone-400 hover:text-stone-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                    @click="close"
+                    :disabled="submitting"
+                >
+                    Cancel
+                </button>
+            </div>
+        </template>
+    </BaseModal>
 </template>
 
 <script setup>
@@ -250,6 +239,7 @@ import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
 import apiClient from '../../services/apiClient'
 import { notifyError } from '../../utils/notifications'
 import { useModelStore } from '../../stores/model'
+import BaseModal from '../common/BaseModal.vue'
 
 const props = defineProps({
     open: {

--- a/frontend/src/components/predict/PredictGenerateModal.vue
+++ b/frontend/src/components/predict/PredictGenerateModal.vue
@@ -1,35 +1,27 @@
 <template>
-    <Teleport
-        to="body"
-        v-if="open"
+    <BaseModal
+        :open="open"
+        @close="handleClose"
     >
-        <div
-            class="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/60 px-4 py-8"
-            role="dialog"
-            aria-modal="true"
-        >
-            <div class="w-full max-w-3xl overflow-hidden rounded-2xl bg-white shadow-xl">
-                <header class="flex items-start justify-between gap-4 border-b border-stone-200 px-6 py-4">
-                    <div>
-                        <p class="text-xs font-semibold uppercase tracking-wider text-stone-500">Forecast workspace</p>
-                        <h2 id="predict-form-heading" class="text-2xl font-semibold text-stone-900">Generate a prediction</h2>
-                    </div>
-                </header>
-                <PredictForm
-                    :disabled="predictionStore.loading"
-                    :initial-filters="predictionStore.lastFilters"
-                    :errors="formErrors"
-                    @submit="handleSubmit"
-                />
-            </div>
-        </div>
-    </Teleport>
+        <template #header>
+            <p class="text-xs font-semibold uppercase tracking-wider text-stone-500">Forecast workspace</p>
+            <h2 id="predict-form-heading" class="text-2xl font-semibold text-stone-900">Generate a prediction</h2>
+        </template>
+
+        <PredictForm
+            :disabled="predictionStore.loading"
+            :initial-filters="predictionStore.lastFilters"
+            :errors="formErrors"
+            @submit="handleSubmit"
+        />
+    </BaseModal>
 </template>
 
 <script setup>
 import PredictForm from "./PredictForm.vue";
 import {usePredictionStore} from "../../stores/prediction.js";
 import {ref} from "vue";
+import BaseModal from "../common/BaseModal.vue";
 
 const props = defineProps({
     open: {
@@ -48,10 +40,15 @@ async function handleSubmit(payload) {
     formErrors.value = {}
     try {
         await predictionStore.submitPrediction(payload)
+        emit('generated')
     } catch (error) {
         if (error.validationErrors) {
             formErrors.value = error.validationErrors
         }
     }
+}
+
+function handleClose() {
+    emit('close')
 }
 </script>

--- a/frontend/src/views/PredictView.vue
+++ b/frontend/src/views/PredictView.vue
@@ -22,23 +22,46 @@
             </button>
         </header>
 
-        <div class="grid gap-6 xl:grid-cols-1">
-            <div class="relative isolate space-y-6">
-                <Suspense>
-                    <template #default>
-                        <MapView
-                            :center="mapCenter"
-                            :points="predictionStore.heatmapPoints"
-                            :radius-km="predictionStore.lastFilters.radiusKm"
-                            :tile-options="heatmapTileOptions"
-                        />
-                    </template>
-                    <template #fallback>
-                        <div class="h-full min-h-[24rem] rounded-xl border border-stone-200/80 bg-white p-6 shadow-sm shadow-stone-200/70">
-                            <p class="text-sm text-stone-500">Loading map…</p>
-                        </div>
-                    </template>
-                </Suspense>
+        <div class="space-y-4">
+            <nav
+                aria-label="Prediction workspace views"
+                class="flex flex-wrap items-center gap-2 border-b border-stone-200"
+            >
+                <button
+                    v-for="tab in tabs"
+                    :key="tab.id"
+                    type="button"
+                    :aria-current="activeTab === tab.id ? 'page' : undefined"
+                    @click="selectTab(tab.id)"
+                    :class="[
+                        'relative -mb-px border-b-2 px-4 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500',
+                        activeTab === tab.id
+                            ? 'border-blue-600 text-blue-600'
+                            : 'border-transparent text-stone-500 hover:text-stone-700',
+                    ]"
+                >
+                    {{ tab.label }}
+                </button>
+            </nav>
+
+            <div v-show="activeTab === 'map'" class="space-y-6" role="region" aria-live="polite">
+                <div class="relative isolate">
+                    <Suspense>
+                        <template #default>
+                            <MapView
+                                :center="mapCenter"
+                                :points="predictionStore.heatmapPoints"
+                                :radius-km="predictionStore.lastFilters.radiusKm"
+                                :tile-options="heatmapTileOptions"
+                            />
+                        </template>
+                        <template #fallback>
+                            <div class="h-full min-h-[24rem] rounded-xl border border-stone-200/80 bg-white p-6 shadow-sm shadow-stone-200/70">
+                                <p class="text-sm text-stone-500">Loading map…</p>
+                            </div>
+                        </template>
+                    </Suspense>
+                </div>
 
                 <PredictionResult
                     v-if="predictionStore.hasPrediction"
@@ -46,7 +69,9 @@
                     :radius="predictionStore.lastFilters.radiusKm"
                     :summary="predictionSummary"
                 />
+            </div>
 
+            <div v-show="activeTab === 'archive'" class="space-y-6" role="region">
                 <PredictionHistory />
             </div>
         </div>
@@ -63,13 +88,11 @@
 <script setup>
 import { computed, defineAsyncComponent, ref } from 'vue'
 import { usePredictionStore } from '../stores/prediction'
-import PredictForm from '../components/predict/PredictForm.vue'
 import PredictionResult from '../components/predict/PredictionResult.vue'
 import PredictionHistory from '../components/predict/PredictionHistory.vue'
-import {storeToRefs} from "pinia";
-import {useAuthStore} from "../stores/auth.js";
-import PredictGenerateModal from "../components/predict/PredictGenerateModal.vue";
-import CreateModelModal from "../components/models/CreateModelModal.vue";
+import { storeToRefs } from 'pinia'
+import { useAuthStore } from '../stores/auth.js'
+import PredictGenerateModal from '../components/predict/PredictGenerateModal.vue'
 
 const MapView = defineAsyncComponent(() => import('../components/map/MapView.vue'))
 
@@ -78,6 +101,11 @@ const authStore = useAuthStore()
 const { isAdmin } = storeToRefs(authStore)
 
 const wizardOpen = ref(false)
+const tabs = [
+    { id: 'map', label: 'Map view' },
+    { id: 'archive', label: 'Prediction archive' },
+]
+const activeTab = ref(tabs[0].id)
 
 const mapCenter = computed(() => predictionStore.currentPrediction?.filters?.center ?? predictionStore.lastFilters.center)
 
@@ -103,5 +131,9 @@ const predictionSummary = computed(() => ({
 
 function openWizard() {
     wizardOpen.value = true;
+}
+
+function selectTab(id) {
+    activeTab.value = id
 }
 </script>


### PR DESCRIPTION
- Reworked BaseModal to emit close events, hide unused navigation/footer regions, and support configurable dialog and body sizing. 
- Updated the prediction and model modals to consume the shared BaseModal, keeping their multi-step workflows and submission handling intact while centralizing layout and close behavior. 
- Introduced a tabbed layout on the Predict view so the map remains the default tab and the archive history lives in a dedicated secondary tab without impacting the map display. 