### PR TITLE
Improve Predict tab layout and insights presentation

### DIFF
--- a/frontend/src/components/common/BaseTabs.vue
+++ b/frontend/src/components/common/BaseTabs.vue
@@ -42,7 +42,7 @@
                 </div>
             </div>
         </div>
-        <div class="w-full">
+        <div class="flex w-full flex-1 flex-col overflow-hidden">
             <slot name="panels" :active="active" />
         </div>
     </component>

--- a/frontend/src/components/predict/PredictionResult.vue
+++ b/frontend/src/components/predict/PredictionResult.vue
@@ -1,59 +1,105 @@
 <template>
     <section
         aria-labelledby="prediction-summary-heading"
-        class="rounded-xl border border-stone-200/80 bg-white shadow-sm shadow-stone-200/70"
+        class="flex h-full flex-col overflow-hidden rounded-3xl border border-stone-200/80 bg-white shadow-xl shadow-stone-200/70"
     >
-        <header class="border-b border-stone-200/80 px-6 py-5">
-            <h2 id="prediction-summary-heading" class="text-xl font-semibold text-stone-900">
-                Prediction results
-            </h2>
-            <p class="mt-2 text-sm text-stone-500">
-                Generated on <time :datetime="summary.generatedAt">{{ formattedGeneratedAt }}</time> for a
-                {{ summary.horizonHours }} hour horizon.
-            </p>
+        <header class="bg-gradient-to-r from-blue-600 via-indigo-500 to-sky-500 px-6 py-6 text-white">
+            <div class="flex flex-wrap items-end justify-between gap-6">
+                <div class="space-y-3">
+                    <p class="text-xs font-semibold uppercase tracking-[0.2em] text-white/70">Latest forecast</p>
+                    <h2 id="prediction-summary-heading" class="text-2xl font-semibold">Prediction insights</h2>
+                    <p class="text-sm text-white/80">
+                        Generated on <time :datetime="summary.generatedAt">{{ formattedGeneratedAt }}</time> for a
+                        {{ horizonLabel }} horizon.
+                    </p>
+                </div>
+                <div class="flex items-center gap-5">
+                    <div
+                        class="relative flex h-28 w-28 items-center justify-center rounded-full border border-white/20 shadow-inner bg-white/10"
+                        :style="riskDialStyle"
+                        role="img"
+                        :aria-label="`Risk score ${riskPercentLabel}`"
+                    >
+                        <span class="text-3xl font-semibold text-white">{{ riskPercentLabel }}</span>
+                    </div>
+                    <div class="space-y-2 text-right">
+                        <p class="text-sm font-semibold uppercase tracking-wide text-white/70">Risk score</p>
+                        <p class="text-3xl font-semibold leading-none text-white">{{ formattedRiskScore }}</p>
+                        <p class="text-xs text-white/80">
+                            Confidence
+                            <span
+                                class="ml-2 inline-flex items-center rounded-full bg-white/15 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-white shadow-sm"
+                            >
+                                {{ confidenceLabel }}
+                            </span>
+                        </p>
+                    </div>
+                </div>
+            </div>
         </header>
-        <div class="grid gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)]">
-            <dl class="grid grid-cols-1 gap-4 sm:grid-cols-3" aria-label="Forecast metrics">
-                <div class="rounded-2xl border border-stone-200/80 bg-stone-50/80 p-5 text-center shadow-inner">
-                    <dt class="text-xs uppercase tracking-wide text-stone-500">Risk score</dt>
-                    <dd class="mt-3 text-3xl font-semibold text-stone-900">{{ summary.riskScore }}</dd>
-                </div>
-                <div class="rounded-2xl border border-stone-200/80 bg-stone-50/80 p-5 text-center shadow-inner">
-                    <dt class="text-xs uppercase tracking-wide text-stone-500">Confidence</dt>
-                    <dd class="mt-3 text-3xl font-semibold text-stone-900">{{ summary.confidence }}</dd>
-                </div>
-                <div class="rounded-2xl border border-stone-200/80 bg-stone-50/80 p-5 text-center shadow-inner">
-                    <dt class="text-xs uppercase tracking-wide text-stone-500">Radius</dt>
-                    <dd class="mt-3 text-3xl font-semibold text-stone-900">{{ radiusLabel }}</dd>
-                </div>
-            </dl>
-            <section aria-labelledby="top-features-heading" class="space-y-3">
+        <div class="grid flex-1 gap-6 px-6 py-6 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+            <section
+                aria-labelledby="forecast-snapshot-heading"
+                class="space-y-6 self-start rounded-2xl border border-stone-200/80 bg-stone-50/70 p-6 shadow-inner"
+            >
+                <header class="space-y-2">
+                    <p class="text-xs font-semibold uppercase tracking-wide text-stone-500">Forecast snapshot</p>
+                    <h3 id="forecast-snapshot-heading" class="text-lg font-semibold text-stone-900">Operational overview</h3>
+                </header>
+                <dl class="space-y-4 text-sm text-stone-600">
+                    <div class="flex items-center justify-between gap-4">
+                        <dt class="text-stone-500">Radius of focus</dt>
+                        <dd class="text-base font-semibold text-stone-900">{{ radiusLabel }}</dd>
+                    </div>
+                    <div class="flex items-center justify-between gap-4">
+                        <dt class="text-stone-500">Horizon</dt>
+                        <dd class="text-base font-semibold text-stone-900">{{ horizonLabel }}</dd>
+                    </div>
+                    <div class="flex items-center justify-between gap-4">
+                        <dt class="text-stone-500">Generated</dt>
+                        <dd class="text-base font-semibold text-stone-900">{{ formattedGeneratedAt }}</dd>
+                    </div>
+                </dl>
+            </section>
+            <section
+                aria-labelledby="top-features-heading"
+                class="flex flex-col gap-4 rounded-2xl border border-stone-200/80 bg-white/85 p-6 shadow-sm shadow-stone-200/60"
+            >
                 <header class="space-y-1">
                     <p class="text-xs font-semibold uppercase tracking-wide text-stone-500">Explainability</p>
                     <h3 id="top-features-heading" class="text-lg font-semibold text-stone-900">Top contributing features</h3>
-                    <p class="text-sm text-stone-500">Explains the leading drivers behind this prediction.</p>
+                    <p class="text-sm text-stone-500">Relative impact is scaled against the leading signal.</p>
                 </header>
-                <table class="min-w-full divide-y divide-stone-200/80" role="table">
-                    <thead>
-                        <tr class="text-left text-xs font-semibold uppercase tracking-wide text-stone-500">
-                            <th class="px-3 py-2" role="columnheader">Feature</th>
-                            <th class="px-3 py-2 text-right" role="columnheader">Contribution</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr
-                            v-for="feature in features"
-                            :key="feature.name"
-                            class="text-sm text-stone-700 odd:bg-stone-50/70"
-                        >
-                            <td class="px-3 py-2" role="cell">{{ feature.name }}</td>
-                            <td class="px-3 py-2 text-right" role="cell">{{ feature.contribution }}</td>
-                        </tr>
-                        <tr v-if="!features.length">
-                            <td class="px-3 py-4 text-sm text-stone-500" colspan="2">No feature contributions available.</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <ul v-if="normalizedFeatures.length" class="flex flex-1 flex-col gap-3" role="list">
+                    <li
+                        v-for="feature in normalizedFeatures"
+                        :key="feature.name"
+                        class="rounded-xl border border-stone-200/70 bg-white/80 p-4 shadow-sm shadow-stone-200/50"
+                    >
+                        <div class="flex items-baseline justify-between gap-3">
+                            <p class="text-sm font-medium text-stone-900">{{ feature.name }}</p>
+                            <p class="text-sm font-semibold text-stone-600">{{ feature.displayValue }}</p>
+                        </div>
+                        <div class="mt-3 h-2 rounded-full bg-stone-200/80" aria-hidden="true">
+                            <div
+                                class="h-2 rounded-full bg-gradient-to-r from-blue-500 via-indigo-500 to-sky-500 transition-all duration-500"
+                                :style="{ width: feature.barWidth }"
+                            />
+                        </div>
+                    </li>
+                    <li
+                        v-if="!hasFeatureIntensity"
+                        class="rounded-xl border border-dashed border-stone-300 bg-stone-50/80 p-4 text-sm text-stone-500"
+                    >
+                        Contributions were provided without intensity values. Displayed order reflects received ranking.
+                    </li>
+                </ul>
+                <p
+                    v-else
+                    class="flex flex-1 items-center justify-center rounded-xl border border-dashed border-stone-300 bg-stone-50/80 p-6 text-sm text-stone-500"
+                >
+                    No feature contributions available for this prediction.
+                </p>
             </section>
         </div>
     </section>
@@ -78,12 +124,106 @@ const props = defineProps({
 })
 
 const formattedGeneratedAt = computed(() => {
-    if (!props.summary.generatedAt) return 'unknown time'
+    if (!props.summary.generatedAt) return 'Unknown time'
     return new Intl.DateTimeFormat('en-GB', {
         dateStyle: 'medium',
         timeStyle: 'short',
     }).format(new Date(props.summary.generatedAt))
 })
 
-const radiusLabel = computed(() => `${props.radius.toFixed(1)} km`)
+const parsedRiskScore = computed(() => {
+    const value = Number.parseFloat(props.summary?.riskScore ?? 0)
+    return Number.isFinite(value) ? value : 0
+})
+
+const formattedRiskScore = computed(() =>
+    new Intl.NumberFormat('en-GB', { maximumFractionDigits: 2, minimumFractionDigits: 2 }).format(parsedRiskScore.value)
+)
+
+const riskPercent = computed(() => {
+    const clamped = Math.min(Math.max(parsedRiskScore.value, 0), 1)
+    return clamped
+})
+
+const riskPercentLabel = computed(() => `${Math.round(riskPercent.value * 100)}%`)
+
+const riskDialStyle = computed(() => {
+    const degrees = Math.round(riskPercent.value * 360)
+    return {
+        backgroundImage: `conic-gradient(rgba(255,255,255,0.92) ${degrees}deg, rgba(255,255,255,0.18) ${degrees}deg)`,
+    }
+})
+
+const confidenceLabel = computed(() => {
+    const confidence = props.summary?.confidence
+    if (typeof confidence === 'string' && confidence.trim().length) {
+        return confidence
+    }
+    return 'Unknown'
+})
+
+const radiusLabel = computed(() => {
+    const numeric = Number.parseFloat(props.radius)
+    if (Number.isFinite(numeric)) {
+        return `${numeric.toFixed(1)} km`
+    }
+    return 'N/A'
+})
+
+const horizonLabel = computed(() => {
+    const numeric = Number.parseFloat(props.summary?.horizonHours ?? '')
+    if (Number.isFinite(numeric)) {
+        return `${numeric} hour${numeric === 1 ? '' : 's'}`
+    }
+    return 'Unknown duration'
+})
+
+const normalizedFeatures = computed(() => {
+    const features = Array.isArray(props.features) ? props.features : []
+    if (!features.length) {
+        return []
+    }
+
+    const sanitized = features.map((feature) => {
+        const name = typeof feature?.name === 'string' && feature.name.trim().length ? feature.name : 'Unnamed feature'
+        const rawContribution = feature?.contribution
+        const numeric = typeof rawContribution === 'number' ? rawContribution : Number.parseFloat(rawContribution)
+        const value = Number.isFinite(numeric) ? numeric : null
+        const displayValue = value === null
+            ? (rawContribution ?? '—')
+            : new Intl.NumberFormat('en-GB', { maximumFractionDigits: 2, minimumFractionDigits: 2 }).format(value)
+
+        return { name, value, displayValue }
+    })
+
+    const max = sanitized.reduce((acc, feature) => {
+        if (feature.value === null) {
+            return acc
+        }
+        return Math.max(acc, Math.abs(feature.value))
+    }, 0)
+
+    return sanitized.map((feature) => {
+        if (feature.value === null || max === 0) {
+            return {
+                ...feature,
+                percentage: 0,
+                barWidth: '0%',
+            }
+        }
+
+        const percentage = Math.round((Math.abs(feature.value) / max) * 100)
+        const width = `${Math.min(100, Math.max(percentage, 6))}%`
+
+        return {
+            ...feature,
+            percentage,
+            barWidth: width,
+        }
+    })
+})
+
+const hasFeatureIntensity = computed(() =>
+    normalizedFeatures.value.some((feature) => feature.percentage > 0)
+)
 </script>

--- a/frontend/src/views/PredictView.vue
+++ b/frontend/src/views/PredictView.vue
@@ -25,11 +25,12 @@
         <BaseTabs
             v-model="activeTab"
             :tabs="tabs"
+            class="flex min-h-[34rem] flex-col"
         >
             <template #panels="{ active }">
                 <BaseTabPanel id="map" :active="active">
                     <div class="flex h-full flex-col gap-6" aria-live="polite" role="region">
-                        <div class="relative isolate">
+                        <div class="relative isolate flex-1 min-h-[24rem]">
                             <Suspense>
                                 <template #default>
                                     <MapView
@@ -46,13 +47,25 @@
                                 </template>
                             </Suspense>
                         </div>
+                    </div>
+                </BaseTabPanel>
 
+                <BaseTabPanel id="insights" :active="active">
+                    <div class="flex h-full flex-col" role="region">
                         <PredictionResult
                             v-if="predictionStore.hasPrediction"
                             :features="predictionStore.featureBreakdown"
                             :radius="predictionStore.lastFilters.radiusKm"
                             :summary="predictionSummary"
                         />
+                        <div
+                            v-else
+                            class="flex flex-1 items-center justify-center rounded-xl border border-dashed border-stone-300 bg-stone-50/80 p-12 text-center text-sm text-stone-500"
+                        >
+                            <p>
+                                Generate a prediction to unlock detailed insights about contributing factors and forecast confidence.
+                            </p>
+                        </div>
                     </div>
                 </BaseTabPanel>
 
@@ -93,6 +106,7 @@ const { isAdmin } = storeToRefs(authStore)
 const wizardOpen = ref(false)
 const tabs = [
     { id: 'map', label: 'Map view' },
+    { id: 'insights', label: 'Prediction insights' },
     { id: 'archive', label: 'Prediction archive' },
 ]
 const activeTab = ref(tabs[0].id)


### PR DESCRIPTION
## Summary
- allow BaseTabs panels to flex so tab content can occupy the remaining vertical space
- reorganize the Predict view with a dedicated insights tab and taller map container
- restyle the prediction insights card with infographic metrics and normalized feature bars

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b95dc19483269b0a1856a70e394d