### PR TITLE
Ensure dataset ingest requests include name and source metadata

### DIFF
--- a/frontend/src/components/dataset/DatasetIngest.vue
+++ b/frontend/src/components/dataset/DatasetIngest.vue
@@ -76,7 +76,7 @@
                             </button>
                             <button
                                 v-else
-                                :disabled="datasetStore.submitting"
+                                :disabled="datasetStore.submitting || !datasetStore.canSubmit"
                                 class="inline-flex items-center justify-center gap-2 rounded-md bg-stone-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:bg-stone-400"
                                 type="button"
                                 @click="submit"
@@ -164,6 +164,9 @@ function close() {
 }
 
 async function submit() {
+    if (!datasetStore.canSubmit) {
+        return
+    }
     const result = await datasetStore.submitIngestion({ submittedAt: new Date().toISOString() })
     if (result) {
         emit('submitted', result)

--- a/frontend/src/components/dataset/steps/PreviewStep.vue
+++ b/frontend/src/components/dataset/steps/PreviewStep.vue
@@ -7,6 +7,24 @@
             </p>
         </header>
 
+        <article class="rounded-lg border border-stone-200 bg-white p-4 text-sm text-stone-700">
+            <h4 class="text-sm font-semibold text-stone-900">Dataset details</h4>
+            <div class="mt-3 space-y-2">
+                <label for="dataset-name" class="block text-sm font-medium text-stone-700">Dataset name</label>
+                <input
+                    id="dataset-name"
+                    v-model="datasetName"
+                    type="text"
+                    name="dataset-name"
+                    class="block w-full rounded-md border border-stone-300 px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    maxlength="255"
+                    autocomplete="off"
+                />
+                <p class="text-xs text-stone-500">Provide a human-readable name. This value defaults to the uploaded file name.</p>
+                <p v-if="isNameMissing" class="text-sm text-rose-600">Dataset name is required.</p>
+            </div>
+        </article>
+
         <article class="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-700">
             <h4 class="text-sm font-semibold text-stone-900">Schema summary</h4>
             <dl class="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -51,4 +69,11 @@ const columns = computed(() => {
     if (!datasetStore.previewRows.length) return []
     return Object.keys(datasetStore.previewRows[0])
 })
+
+const datasetName = computed({
+    get: () => datasetStore.form.name,
+    set: (value) => datasetStore.setDatasetName(value),
+})
+
+const isNameMissing = computed(() => datasetStore.form.name.trim() === '')
 </script>


### PR DESCRIPTION
## Summary
- track dataset name and source information in the ingest store so requests always include the required fields
- auto-infer a dataset name from the uploaded file while allowing manual edits and URL source handling hooks
- add a preview-step form for editing the dataset name and block submission until the details are complete

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5bc58bd908326bd623fafaa3afae4