### PR TITLE
Add dataset submission guard in store

### DIFF
--- a/frontend/src/components/dataset/DatasetIngest.vue
+++ b/frontend/src/components/dataset/DatasetIngest.vue
@@ -73,7 +73,7 @@
                             </button>
                             <button
                                 v-else
-                                :disabled="datasetStore.submitting || !datasetStore.canSubmit"
+                                :disabled="datasetStore.submitting || !canSubmit"
                                 class="inline-flex items-center justify-center gap-2 rounded-md bg-stone-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:bg-stone-400"
                                 type="button"
                                 @click="submit"
@@ -119,7 +119,7 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue', 'submitted'])
 
 const datasetStore = useDatasetStore()
-const { step } = storeToRefs(datasetStore)
+const { step, canSubmit } = storeToRefs(datasetStore)
 
 const steps = computed(() => {
     const orderedSteps = [
@@ -232,7 +232,7 @@ function close() {
 }
 
 async function submit() {
-    if (!datasetStore.canSubmit) {
+    if (!canSubmit.value) {
         return
     }
     const result = await datasetStore.submitIngestion({ submittedAt: new Date().toISOString() })

--- a/frontend/src/stores/dataset.js
+++ b/frontend/src/stores/dataset.js
@@ -60,6 +60,21 @@ export const useDatasetStore = defineStore('dataset', {
                 return false
             }
         },
+        canSubmit() {
+            if (!this.detailsValid) {
+                return false
+            }
+
+            if (this.sourceType === 'url') {
+                return this.sourceUriValid
+            }
+
+            if (this.sourceType === 'file') {
+                return this.hasValidFile && this.mappedFields >= 3
+            }
+
+            return false
+        },
         sourceStepValid() {
             if (this.sourceType === 'url') {
                 return this.sourceUriValid


### PR DESCRIPTION
## Summary
- add a canSubmit getter to the dataset store to centralise submission validation
- update the ingest wizard to consume the new getter for button state and submission guard
