### PR TITLE
Add label mapping support to dataset wizard

### DIFF
--- a/backend/tests/Feature/DatasetApiTest.php
+++ b/backend/tests/Feature/DatasetApiTest.php
@@ -44,6 +44,7 @@ CSV;
                 'latitude' => 'Latitude',
                 'longitude' => 'Longitude',
                 'category' => 'Type',
+                'label' => 'Outcome',
             ],
         ]);
 
@@ -57,6 +58,7 @@ CSV;
             'latitude' => 'Latitude',
             'longitude' => 'Longitude',
             'category' => 'Type',
+            'label' => 'Outcome',
         ], $data['schema']);
         $this->assertSame($data['schema'], $data['metadata']['schema_mapping']);
         $this->assertSame(1, $data['features_count']);
@@ -71,6 +73,7 @@ CSV;
             'latitude' => ['column' => 'Latitude', 'sample' => '52.019256'],
             'longitude' => ['column' => 'Longitude', 'sample' => '-0.225046'],
             'category' => ['column' => 'Type', 'sample' => 'Person search'],
+            'label' => ['column' => 'Outcome', 'sample' => 'A no further action disposal'],
         ], $data['metadata']['derived_features']);
         $this->assertSame('test', $data['metadata']['ingested_via']);
 

--- a/frontend/src/components/dataset/steps/SchemaStep.vue
+++ b/frontend/src/components/dataset/steps/SchemaStep.vue
@@ -32,6 +32,17 @@
                     <option v-for="option in columnOptions" :key="`risk-${option}`" :value="option">{{ option }}</option>
                 </select>
             </div>
+            <div class="md:col-span-2 flex flex-col gap-2">
+                <label for="optional-label" class="text-sm font-medium text-stone-800">Label column</label>
+                <select
+                    id="optional-label"
+                    v-model="localMapping.label"
+                    class="rounded-md border border-stone-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                >
+                    <option value="">No label</option>
+                    <option v-for="option in columnOptions" :key="`label-${option}`" :value="option">{{ option }}</option>
+                </select>
+            </div>
         </div>
     </section>
 </template>
@@ -60,6 +71,7 @@ const localMapping = reactive({
     longitude: datasetStore.schemaMapping.longitude || '',
     category: datasetStore.schemaMapping.category || '',
     risk: datasetStore.schemaMapping.risk || '',
+    label: datasetStore.schemaMapping.label || '',
 })
 
 watch(


### PR DESCRIPTION
## Summary
- add a label column selector to the schema mapping step so it persists alongside the existing fields
- rely on the shared schema mapping store so the preview summary lists the optional label when present
- extend the dataset ingestion feature test to assert the API echoes the label mapping in its payload

## Testing
- composer test -- --filter=DatasetApiTest *(fails: composer install requires a GitHub token to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d6871e4e3883269fb43d0efbddad83