### PR TITLE
Add admin-only user management API endpoints

### DIFF
--- a/backend/app/Http/Controllers/Api/v1/UserController.php
+++ b/backend/app/Http/Controllers/Api/v1/UserController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1;
+
+use App\Enums\Role;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreUserRequest;
+use App\Http\Requests\UpdateUserRequest;
+use App\Http\Requests\UpdateUserRoleRequest;
+use App\Models\User;
+use App\Support\ResolvesRoles;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class UserController extends Controller
+{
+    use ResolvesRoles;
+
+    public function __construct()
+    {
+        $this->middleware(['auth.api', 'throttle:api']);
+    }
+
+    public function index(Request $request): JsonResponse
+    {
+        $this->ensureAdmin($request->user());
+
+        $users = User::query()->orderBy('name')->get();
+
+        return response()->json($users);
+    }
+
+    public function store(StoreUserRequest $request): JsonResponse
+    {
+        $user = User::create($request->validated());
+
+        return response()->json($user, Response::HTTP_CREATED);
+    }
+
+    public function update(UpdateUserRequest $request, User $user): JsonResponse
+    {
+        $user->fill($request->validated());
+        $user->save();
+
+        return response()->json($user);
+    }
+
+    public function destroy(Request $request, User $user): Response
+    {
+        $this->ensureAdmin($request->user());
+
+        $user->delete();
+
+        return response()->noContent();
+    }
+
+    public function assignRole(UpdateUserRoleRequest $request, User $user): JsonResponse
+    {
+        $user->role = Role::from($request->validated()['role']);
+        $user->save();
+
+        return response()->json($user);
+    }
+
+    private function ensureAdmin(mixed $user): void
+    {
+        if ($this->resolveRole($user) !== Role::Admin) {
+            abort(Response::HTTP_FORBIDDEN);
+        }
+    }
+}

--- a/backend/app/Http/Requests/StoreUserRequest.php
+++ b/backend/app/Http/Requests/StoreUserRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\Role;
+use App\Support\ResolvesRoles;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rule;
+
+class StoreUserRequest extends FormRequest
+{
+    use ResolvesRoles;
+
+    public function authorize(): bool
+    {
+        return $this->resolveRole($this->user()) === Role::Admin;
+    }
+
+    /**
+     * @return array<string, array<int, string|Rule>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255', Rule::unique('users', 'email')],
+            'password' => ['required', 'string', 'min:8'],
+            'role' => ['required', Rule::enum(Role::class)],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function validated($key = null, $default = null): array
+    {
+        $validated = parent::validated($key, $default);
+
+        if (array_key_exists('password', $validated)) {
+            $validated['password'] = Hash::make($validated['password']);
+        }
+
+        return $validated;
+    }
+}

--- a/backend/app/Http/Requests/UpdateUserRequest.php
+++ b/backend/app/Http/Requests/UpdateUserRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\Role;
+use App\Support\ResolvesRoles;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rule;
+
+class UpdateUserRequest extends FormRequest
+{
+    use ResolvesRoles;
+
+    public function authorize(): bool
+    {
+        return $this->resolveRole($this->user()) === Role::Admin;
+    }
+
+    /**
+     * @return array<string, array<int, string|Rule>>
+     */
+    public function rules(): array
+    {
+        $user = $this->route('user');
+        $userId = is_object($user) && method_exists($user, 'getKey') ? $user->getKey() : $user;
+
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'email' => [
+                'sometimes',
+                'required',
+                'email',
+                'max:255',
+                Rule::unique('users', 'email')->ignore($userId),
+            ],
+            'password' => ['sometimes', 'required', 'string', 'min:8'],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function validated($key = null, $default = null): array
+    {
+        $validated = parent::validated($key, $default);
+
+        if (array_key_exists('password', $validated)) {
+            $validated['password'] = Hash::make($validated['password']);
+        }
+
+        return $validated;
+    }
+}

--- a/backend/app/Http/Requests/UpdateUserRoleRequest.php
+++ b/backend/app/Http/Requests/UpdateUserRoleRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\Role;
+use App\Support\ResolvesRoles;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateUserRoleRequest extends FormRequest
+{
+    use ResolvesRoles;
+
+    public function authorize(): bool
+    {
+        return $this->resolveRole($this->user()) === Role::Admin;
+    }
+
+    /**
+     * @return array<string, array<int, string|Rule>>
+     */
+    public function rules(): array
+    {
+        return [
+            'role' => ['required', Rule::enum(Role::class)],
+        ];
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\v1\HexController;
 use App\Http\Controllers\Api\v1\ModelController;
 use App\Http\Controllers\Api\v1\NlqController;
 use App\Http\Controllers\Api\v1\PredictionController;
+use App\Http\Controllers\Api\v1\UserController;
 use Illuminate\Support\Facades\Route;
 
 /**
@@ -65,5 +66,13 @@ Route::prefix('v1')->group(function () use ($authRoutes): void {
         Route::get('/predictions', [PredictionController::class, 'index']);
         Route::post('/predictions', [PredictionController::class, 'store']);
         Route::get('/predictions/{id}', [PredictionController::class, 'show']);
+
+        Route::patch('/users/{user}/role', [UserController::class, 'assignRole']);
+        Route::apiResource('users', UserController::class)->only([
+            'index',
+            'store',
+            'update',
+            'destroy',
+        ]);
     });
 });

--- a/backend/tests/Feature/Api/UserManagementTest.php
+++ b/backend/tests/Feature/Api/UserManagementTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Enums\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_create_update_and_delete_users(): void
+    {
+        $tokens = $this->issueTokensForRole(Role::Admin);
+
+        $createResponse = $this->withHeader('Authorization', 'Bearer ' . $tokens['accessToken'])
+            ->postJson('/api/v1/users', [
+                'name' => 'Jane Doe',
+                'email' => 'jane@example.com',
+                'password' => 'secret-password',
+                'role' => Role::Analyst->value,
+            ]);
+
+        $createResponse->assertCreated();
+        $createResponse->assertJsonFragment([
+            'name' => 'Jane Doe',
+            'email' => 'jane@example.com',
+            'role' => Role::Analyst->value,
+        ]);
+
+        $userId = $createResponse->json('id');
+        $this->assertNotNull($userId);
+
+        $createdUser = User::find($userId);
+        $this->assertNotNull($createdUser);
+        $this->assertTrue(Hash::check('secret-password', $createdUser->password));
+
+        $updateResponse = $this->withHeader('Authorization', 'Bearer ' . $tokens['accessToken'])
+            ->patchJson('/api/v1/users/' . $userId, [
+                'name' => 'Jane A. Doe',
+                'password' => 'new-secret-password',
+            ]);
+
+        $updateResponse->assertOk();
+        $updateResponse->assertJsonFragment(['name' => 'Jane A. Doe']);
+
+        $updatedUser = $createdUser->fresh();
+        $this->assertSame('Jane A. Doe', $updatedUser->name);
+        $this->assertTrue(Hash::check('new-secret-password', $updatedUser->password));
+
+        $deleteResponse = $this->withHeader('Authorization', 'Bearer ' . $tokens['accessToken'])
+            ->deleteJson('/api/v1/users/' . $userId);
+
+        $deleteResponse->assertNoContent();
+        $this->assertDatabaseMissing('users', ['id' => $userId]);
+    }
+
+    public function test_admin_can_assign_roles(): void
+    {
+        $tokens = $this->issueTokensForRole(Role::Admin);
+        $user = User::factory()->create([
+            'role' => Role::Viewer,
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $tokens['accessToken'])
+            ->patchJson('/api/v1/users/' . $user->getKey() . '/role', [
+                'role' => Role::Analyst->value,
+            ]);
+
+        $response->assertOk();
+        $response->assertJsonFragment(['role' => Role::Analyst->value]);
+
+        $this->assertTrue($user->fresh()->role() === Role::Analyst);
+    }
+
+    public function test_non_admins_are_forbidden(): void
+    {
+        $tokens = $this->issueTokensForRole(Role::Viewer);
+
+        $this->withHeader('Authorization', 'Bearer ' . $tokens['accessToken'])
+            ->getJson('/api/v1/users')
+            ->assertForbidden();
+
+        $this->withHeader('Authorization', 'Bearer ' . $tokens['accessToken'])
+            ->postJson('/api/v1/users', [
+                'name' => 'Blocked User',
+                'email' => 'blocked@example.com',
+                'password' => 'blocked-password',
+                'role' => Role::Viewer->value,
+            ])
+            ->assertForbidden();
+
+        $user = User::factory()->create([
+            'role' => Role::Viewer,
+        ]);
+
+        $this->withHeader('Authorization', 'Bearer ' . $tokens['accessToken'])
+            ->patchJson('/api/v1/users/' . $user->getKey() . '/role', [
+                'role' => Role::Analyst->value,
+            ])
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- add an admin-gated API controller for managing users with CRUD and role assignment endpoints
- introduce dedicated request classes that validate payloads and hash passwords
- expose the routes under the authenticated API group and cover behaviour with feature tests