### PR TITLE
Honor session.secure when issuing refresh cookies

### DIFF
--- a/backend/app/Http/Controllers/Api/v1/AuthController.php
+++ b/backend/app/Http/Controllers/Api/v1/AuthController.php
@@ -111,13 +111,15 @@ class AuthController extends Controller
 
     private function setRefreshCookie(JsonResponse $response, string $refreshToken): JsonResponse
     {
+        $secure = (bool) (config('session.secure') ?? false);
+
         $cookie = cookie(
             SanctumTokenManager::REFRESH_COOKIE_NAME,
             $refreshToken,
             SanctumTokenManager::REFRESH_TOKEN_TTL_DAYS * 24 * 60,
             self::REFRESH_COOKIE_PATH,
             config('session.domain'),
-            (bool) (config('session.secure_cookie') ?? true),
+            $secure,
             true,
             false,
             config('session.same_site') ?? 'lax'
@@ -128,13 +130,15 @@ class AuthController extends Controller
 
     private function forgetRefreshCookie(JsonResponse $response): JsonResponse
     {
+        $secure = (bool) (config('session.secure') ?? false);
+
         $cookie = cookie(
             SanctumTokenManager::REFRESH_COOKIE_NAME,
             '',
             -1,
             self::REFRESH_COOKIE_PATH,
             config('session.domain'),
-            (bool) (config('session.secure_cookie') ?? true),
+            $secure,
             true,
             false,
             config('session.same_site') ?? 'lax'

--- a/backend/tests/Feature/AuthCookieTest.php
+++ b/backend/tests/Feature/AuthCookieTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Models\User;
+use App\Support\SanctumTokenManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+/**
+ * The SPA relies on the refresh cookie to restoreSession, so local HTTP environments must be
+ * able to issue it without the Secure attribute when session.secure is disabled.
+ */
+class AuthCookieTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_refresh_cookie_secure_attribute_respects_configuration(): void
+    {
+        $user = User::factory()->create([
+            'password' => Hash::make('secret-password'),
+            'role' => Role::Viewer,
+        ]);
+
+        config(['session.secure' => false]);
+
+        $httpResponse = $this->postJson('/api/v1/auth/login', [
+            'email' => $user->email,
+            'password' => 'secret-password',
+        ]);
+
+        $httpResponse->assertOk();
+        $httpCookie = $httpResponse->getCookie(SanctumTokenManager::REFRESH_COOKIE_NAME);
+        $this->assertNotNull($httpCookie);
+        $this->assertFalse($httpCookie->isSecure());
+
+        config(['session.secure' => true]);
+
+        $httpsResponse = $this->postJson('/api/v1/auth/login', [
+            'email' => $user->email,
+            'password' => 'secret-password',
+        ]);
+
+        $httpsResponse->assertOk();
+        $httpsCookie = $httpsResponse->getCookie(SanctumTokenManager::REFRESH_COOKIE_NAME);
+        $this->assertNotNull($httpsCookie);
+        $this->assertTrue($httpsCookie->isSecure());
+    }
+}


### PR DESCRIPTION
## Summary
- update the v1 AuthController to read the `session.secure` flag when issuing and clearing refresh cookies
- add a regression test that documents the SPA dependency on a non-secure cookie in local HTTP environments while keeping production behaviour secure