### PR TITLE
Skip optimize warm-up when using database cache

### DIFF
--- a/scripts/init-backend.sh
+++ b/scripts/init-backend.sh
@@ -50,5 +50,12 @@ php -r "file_exists('$APP_DIR/.env') || copy('$APP_DIR/.env.example', '$APP_DIR/
 
 php artisan key:generate || true
 
-# Warm framework caches so php-fpm can serve requests immediately.
-php artisan optimize || true
+# Warm framework caches so php-fpm can serve requests immediately. When the
+# database cache driver is active the "cache" table may not exist until after
+# migrations run, so skip the optimize warm-up in that scenario to avoid
+# failing on startup.
+if [ "${CACHE_STORE:-}" = "database" ]; then
+  echo "Skipping php artisan optimize before migrations because CACHE_STORE=database."
+else
+  php artisan optimize || true
+fi


### PR DESCRIPTION
## Summary
- skip the php artisan optimize warm-up in the init script when CACHE_STORE=database to avoid hitting the cache table before migrations run

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d6aaf8bb8483268c1bed7d4302a060