### PR TITLE
Add broadcast channel authorization for model status updates

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -6,6 +6,7 @@ use App\Providers\AppServiceProvider;
 use App\Providers\AuthServiceProvider;
 use App\Providers\HorizonServiceProvider;
 use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Broadcasting;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\HandleCors;
@@ -19,6 +20,10 @@ return Application::configure(basePath: dirname(__DIR__))
         AuthServiceProvider::class,
         HorizonServiceProvider::class,
     ])
+    ->withBroadcasting(function (Broadcasting $broadcasting): void {
+        $broadcasting->routes();
+        $broadcasting->channels(__DIR__.'/../routes/channels.php');
+    })
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         api: __DIR__.'/../routes/api.php',

--- a/backend/routes/channels.php
+++ b/backend/routes/channels.php
@@ -1,0 +1,10 @@
+<?php
+
+use App\Models\PredictiveModel;
+use Illuminate\Support\Facades\Broadcast;
+
+Broadcast::channel('models.{modelId}.status', function ($user, int $modelId): bool {
+    $model = PredictiveModel::find($modelId);
+
+    return $model !== null && $user->can('view', $model);
+});

--- a/backend/tests/Feature/BroadcastAuthTest.php
+++ b/backend/tests/Feature/BroadcastAuthTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\PredictiveModel;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BroadcastAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authorized_user_can_authenticate_for_model_status_channel(): void
+    {
+        $user = User::factory()->create();
+        $model = PredictiveModel::factory()->create();
+
+        $this->actingAs($user);
+
+        $response = $this->post('/broadcasting/auth', [
+            'channel_name' => 'private-models.'.$model->getKey().'.status',
+            'socket_id' => '12345.67890',
+        ]);
+
+        $response->assertOk();
+    }
+
+    public function test_request_is_rejected_for_unknown_model(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $response = $this->post('/broadcasting/auth', [
+            'channel_name' => 'private-models.999999.status',
+            'socket_id' => '98765.43210',
+        ]);
+
+        $response->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- register the models status broadcast channel with authorization via the existing policy
- boot Laravel broadcasting to load the new channels file
- cover broadcast auth success and failure scenarios with a feature test

## Testing
- php artisan test --filter=BroadcastAuthTest *(fails: missing vendor dependencies and composer install blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b948558483269a18fe960a835c0d