### PR TITLE
Connect admin user management to backend API

### DIFF
--- a/frontend/src/components/users/UserCreateModal.vue
+++ b/frontend/src/components/users/UserCreateModal.vue
@@ -8,6 +8,9 @@
         </template>
 
         <form id="create-user-form" class="space-y-5" @submit.prevent="handleSubmit">
+            <div v-if="errors.general" class="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+                {{ errors.general }}
+            </div>
             <div>
                 <label for="user-name" class="block text-sm font-medium text-stone-700">Full name</label>
                 <input

--- a/frontend/src/components/users/UserRoleModal.vue
+++ b/frontend/src/components/users/UserRoleModal.vue
@@ -8,6 +8,9 @@
         </template>
 
         <form id="update-user-role" class="space-y-5" @submit.prevent="handleSubmit">
+            <div v-if="errors.general" class="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+                {{ errors.general }}
+            </div>
             <div class="rounded-xl border border-stone-200 bg-stone-50/70 p-4 text-sm">
                 <p class="font-semibold text-stone-900">{{ user?.name || 'Unknown user' }}</p>
                 <p class="text-xs text-stone-500">{{ user?.email }}</p>

--- a/frontend/src/stores/__tests__/user.spec.js
+++ b/frontend/src/stores/__tests__/user.spec.js
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('../../services/apiClient', () => ({
+    default: {
+        get: vi.fn(),
+        post: vi.fn(),
+        patch: vi.fn(),
+        delete: vi.fn(),
+    },
+}))
+
+import apiClient from '../../services/apiClient'
+import { useUserStore } from '../user'
+
+describe('useUserStore', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        vi.clearAllMocks()
+    })
+
+    it('fetches users from the API', async () => {
+        apiClient.get.mockResolvedValue({
+            data: [
+                { id: '1', name: 'Test User', email: 'test@example.com', role: 'viewer' },
+            ],
+        })
+
+        const store = useUserStore()
+        await store.fetchUsers()
+
+        expect(apiClient.get).toHaveBeenCalledWith('/users')
+        expect(store.users).toHaveLength(1)
+        expect(store.users[0].id).toBe('1')
+        expect(store.roles).toContain('viewer')
+    })
+
+    it('records an error when fetching users fails', async () => {
+        const error = new Error('Request failed')
+        apiClient.get.mockRejectedValue(error)
+
+        const store = useUserStore()
+        await store.fetchUsers()
+
+        expect(apiClient.get).toHaveBeenCalledWith('/users')
+        expect(store.users).toEqual([])
+        expect(store.error).toContain('Request failed')
+    })
+
+    it('creates a user via the API and syncs state', async () => {
+        apiClient.post.mockResolvedValue({
+            data: { id: '2', name: 'New User', email: 'new@example.com', role: 'analyst' },
+        })
+
+        const store = useUserStore()
+        const { user, errors } = await store.createUser({
+            name: 'New User',
+            email: 'new@example.com',
+            role: 'analyst',
+        })
+
+        expect(apiClient.post).toHaveBeenCalledWith('/users', {
+            name: 'New User',
+            email: 'new@example.com',
+            role: 'analyst',
+        })
+        expect(errors).toBeNull()
+        expect(user?.id).toBe('2')
+        expect(store.users[0]?.id).toBe('2')
+        expect(store.roles).toContain('analyst')
+    })
+
+    it('surfaces validation errors when create user fails', async () => {
+        const error = new Error('Validation failed')
+        error.validationErrors = { email: 'Email already taken' }
+        apiClient.post.mockRejectedValue(error)
+
+        const store = useUserStore()
+        const { user, errors } = await store.createUser({})
+
+        expect(apiClient.post).toHaveBeenCalledWith('/users', {})
+        expect(user).toBeNull()
+        expect(errors).toEqual({ email: 'Email already taken' })
+    })
+
+    it('updates the user role via the API', async () => {
+        apiClient.get.mockResolvedValue({ data: [] })
+        const store = useUserStore()
+        store.users = [{ id: '3', name: 'Role User', email: 'role@example.com', role: 'viewer' }]
+
+        apiClient.patch.mockResolvedValue({
+            data: { id: '3', name: 'Role User', email: 'role@example.com', role: 'admin' },
+        })
+
+        const { user, errors } = await store.updateUserRole('3', 'admin')
+
+        expect(apiClient.patch).toHaveBeenCalledWith('/users/3/role', { role: 'admin' })
+        expect(errors).toBeNull()
+        expect(user?.role).toBe('admin')
+        expect(store.users[0]?.role).toBe('admin')
+        expect(store.roles).toContain('admin')
+    })
+
+    it('deletes a user via the API and refreshes local state', async () => {
+        const store = useUserStore()
+        store.users = [
+            { id: '4', name: 'Remove Me', email: 'remove@example.com', role: 'viewer' },
+            { id: '5', name: 'Stay', email: 'stay@example.com', role: 'analyst' },
+        ]
+
+        apiClient.delete.mockResolvedValue({})
+
+        const { success, errors } = await store.deleteUser('4')
+
+        expect(apiClient.delete).toHaveBeenCalledWith('/users/4')
+        expect(success).toBe(true)
+        expect(errors).toBeUndefined()
+        expect(store.users).toHaveLength(1)
+        expect(store.users[0]?.id).toBe('5')
+        expect(store.roles).toContain('analyst')
+    })
+})

--- a/frontend/src/views/admin/AdminUsersView.vue
+++ b/frontend/src/views/admin/AdminUsersView.vue
@@ -39,6 +39,13 @@
             @reset="handlePasswordReset"
         />
 
+        <div
+            v-if="error"
+            class="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700"
+        >
+            {{ error }}
+        </div>
+
         <UserTable
             :users="users"
             :loading="loading"
@@ -60,7 +67,7 @@ import UserTable from '../../components/users/UserTable.vue'
 import { useUserStore } from '../../stores/user'
 
 const userStore = useUserStore()
-const { users, loading, roles, actionState } = storeToRefs(userStore)
+const { users, loading, roles, actionState, error } = storeToRefs(userStore)
 
 const createModalOpen = ref(false)
 const roleModalOpen = ref(false)
@@ -75,9 +82,9 @@ function openCreateModal() {
     createModalOpen.value = true
 }
 
-function handleUserCreated() {
+async function handleUserCreated() {
     createModalOpen.value = false
-    userStore.fetchUsers()
+    await userStore.fetchUsers()
 }
 
 function openRoleModal(user) {
@@ -90,9 +97,9 @@ function closeRoleModal() {
     selectedUser.value = null
 }
 
-function handleRoleUpdated() {
+async function handleRoleUpdated() {
     roleModalOpen.value = false
-    userStore.fetchUsers()
+    await userStore.fetchUsers()
     selectedUser.value = null
 }
 
@@ -122,9 +129,12 @@ async function handleDeleteUser(user) {
         return
     }
 
-    await userStore.deleteUser(user.id)
-    if (selectedUser.value?.id === user.id) {
-        selectedUser.value = null
+    const { success } = await userStore.deleteUser(user.id)
+    if (success) {
+        await userStore.fetchUsers()
+        if (selectedUser.value?.id === user.id) {
+            selectedUser.value = null
+        }
     }
 }
 </script>


### PR DESCRIPTION
## Summary
- replace the admin user Pinia store to use the backend API for CRUD actions and role syncing
- surface API validation feedback and loading state in the admin user modals and view while refreshing data after mutations
- add a focused Pinia store test suite that verifies the correct API requests are issued for user management

## Testing
- npx vitest run src/stores/__tests__/user.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d6d1a78f8c8326ac240b94838c2c47