### PR TITLE
Separate Pusher configuration from Reverb defaults

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -65,6 +65,16 @@ REVERB_SERVER_HOST=0.0.0.0
 REVERB_SERVER_PORT=8080
 REVERB_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 
+# Uncomment and configure the following values when using the hosted Pusher service
+# instead of the bundled Laravel Reverb server.
+# PUSHER_APP_ID=
+# PUSHER_APP_KEY=
+# PUSHER_APP_SECRET=
+# PUSHER_APP_CLUSTER=
+# PUSHER_HOST=
+# PUSHER_PORT=
+# PUSHER_SCHEME=https
+
 MAIL_MAILER=log
 MAIL_SCHEME=null
 MAIL_HOST=127.0.0.1

--- a/backend/config/broadcasting.php
+++ b/backend/config/broadcasting.php
@@ -39,6 +39,18 @@ return (function () {
                 ],
             ];
 
+            $pusherConfigured = static function () {
+                foreach (['PUSHER_APP_ID', 'PUSHER_APP_KEY', 'PUSHER_APP_SECRET'] as $key) {
+                    $value = env($key);
+
+                    if ($value === null || $value === '') {
+                        return false;
+                    }
+                }
+
+                return true;
+            };
+
             $pusherScheme = strtolower((string) env('PUSHER_SCHEME', 'https'));
             $pusherOptions = [
                 'cluster' => env('PUSHER_APP_CLUSTER'),
@@ -49,23 +61,25 @@ return (function () {
                 $pusherOptions['scheme'] = $pusherScheme;
             }
 
-            if (($host = env('PUSHER_HOST')) !== null) {
+            if (($host = env('PUSHER_HOST')) !== null && $host !== '') {
                 $pusherOptions['host'] = $host;
             }
 
-            if (($port = env('PUSHER_PORT')) !== null) {
+            if (($port = env('PUSHER_PORT')) !== null && $port !== '') {
                 $pusherOptions['port'] = (int) $port;
             }
 
             return [
                 'reverb' => $reverb,
-                'pusher' => [
-                    'driver' => 'pusher',
-                    'key' => env('PUSHER_APP_KEY'),
-                    'secret' => env('PUSHER_APP_SECRET'),
-                    'app_id' => env('PUSHER_APP_ID'),
-                    'options' => $pusherOptions,
-                ],
+                'pusher' => $pusherConfigured()
+                    ? [
+                        'driver' => 'pusher',
+                        'key' => env('PUSHER_APP_KEY'),
+                        'secret' => env('PUSHER_APP_SECRET'),
+                        'app_id' => env('PUSHER_APP_ID'),
+                        'options' => $pusherOptions,
+                    ]
+                    : $reverb,
                 'ably' => [
                     'driver' => 'ably',
                     'key' => env('ABLY_KEY'),

--- a/backend/config/broadcasting.php
+++ b/backend/config/broadcasting.php
@@ -24,7 +24,7 @@ return (function () {
         'default' => $driver,
 
         'connections' => (function () use ($resolve) {
-            $scheme = strtolower((string) $resolve('REVERB_SCHEME', 'PUSHER_SCHEME', 'http'));
+            $reverbScheme = strtolower((string) $resolve('REVERB_SCHEME', 'PUSHER_SCHEME', 'http'));
 
             $reverb = [
                 'driver' => 'reverb',
@@ -34,14 +34,38 @@ return (function () {
                 'options' => [
                     'host' => $resolve('REVERB_HOST', 'PUSHER_HOST', '127.0.0.1'),
                     'port' => (int) $resolve('REVERB_PORT', 'PUSHER_PORT', 8080),
-                    'scheme' => $scheme,
-                    'useTLS' => $scheme === 'https',
+                    'scheme' => $reverbScheme,
+                    'useTLS' => $reverbScheme === 'https',
                 ],
             ];
 
+            $pusherScheme = strtolower((string) env('PUSHER_SCHEME', 'https'));
+            $pusherOptions = [
+                'cluster' => env('PUSHER_APP_CLUSTER'),
+                'useTLS' => $pusherScheme === 'https',
+            ];
+
+            if ($pusherScheme !== '') {
+                $pusherOptions['scheme'] = $pusherScheme;
+            }
+
+            if (($host = env('PUSHER_HOST')) !== null) {
+                $pusherOptions['host'] = $host;
+            }
+
+            if (($port = env('PUSHER_PORT')) !== null) {
+                $pusherOptions['port'] = (int) $port;
+            }
+
             return [
                 'reverb' => $reverb,
-                'pusher' => $reverb,
+                'pusher' => [
+                    'driver' => 'pusher',
+                    'key' => env('PUSHER_APP_KEY'),
+                    'secret' => env('PUSHER_APP_SECRET'),
+                    'app_id' => env('PUSHER_APP_ID'),
+                    'options' => $pusherOptions,
+                ],
                 'ably' => [
                     'driver' => 'ably',
                     'key' => env('ABLY_KEY'),


### PR DESCRIPTION
## Summary
- ensure the Pusher broadcasting driver reads its own PUSHER_* environment variables rather than inheriting Reverb defaults
- document the optional PUSHER_* configuration block in the example environment file so hosted Pusher setups can opt in cleanly